### PR TITLE
fix: block destructive save race that wiped maps on slow load

### DIFF
--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -483,6 +483,11 @@
             let nodes = [];
             let links = [];
             let selectedNode = null;
+            // Load gate: for existing maps, saveMap() must not POST until the
+            // /json load resolves — otherwise the empty client arrays would be
+            // sent to the destructive replaceMapContent() backend, wiping the map.
+            let mapDataLoaded = !mapId;       // new maps have nothing to load
+            let mapDataLoadFailed = false;
             let devicesCache = [];
             let canvas = null;
             let ctx = null;
@@ -1179,9 +1184,18 @@
                 fetch(`{{ url('plugin/WeathermapNG/api/maps') }}/${id}/json`, {
                     headers: { 'Accept': 'application/json' }
                 })
-                .then(r => r.json())
+                .then(r => {
+                    if (!r.ok) {
+                        mapDataLoadFailed = true;
+                        throw new Error('HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : ''));
+                    }
+                    return r.json();
+                })
                 .then(data => {
-                    if (!data) return;
+                    if (!data) {
+                        mapDataLoadFailed = true;
+                        return;
+                    }
                     nodes = (data.nodes || []).map(node => ({
                         id: node.id,
                         dbId: node.id,
@@ -1213,6 +1227,7 @@
                     if (data.width && canvas) canvas.width = data.width;
                     if (data.height && canvas) canvas.height = data.height;
 
+                    mapDataLoaded = true;
                     renderEditor();
                     renderLinksList();
                     renderNodesList();
@@ -1220,7 +1235,9 @@
                     markSaved();
                 })
                 .catch(error => {
+                    mapDataLoadFailed = true;
                     console.error('Failed to load map data', error);
+                    WMNGToast.error('Failed to load map data: ' + error.message + '. Saving is disabled until the map loads.', { duration: 5000 });
                 });
             }
 
@@ -1361,6 +1378,20 @@
                     return;
                 }
 
+                // Destructive-save guard: for an existing map, refuse to save
+                // until the /json load has completed successfully. The backend
+                // replaceMapContent() deletes all nodes/links then recreates
+                // from the client arrays — saving before the load resolves (or
+                // after it failed) would POST empty arrays and wipe the map.
+                if (mapId && !mapDataLoaded) {
+                    if (mapDataLoadFailed) {
+                        WMNGToast.error('Cannot save: map data failed to load. Reload the page and try again.', { duration: 5000 });
+                    } else {
+                        WMNGToast.warning('Map is still loading, please wait a moment and try again.', { duration: 3000 });
+                    }
+                    return;
+                }
+
                 const baseHeaders = {
                     'Content-Type': 'application/json',
                     'Accept': 'application/json',
@@ -1375,7 +1406,12 @@
                         headers: baseHeaders,
                         body: JSON.stringify(payload),
                     })
-                    .then(r => r.json())
+                    .then(r => {
+                        if (!r.ok) {
+                            throw new Error('HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : ''));
+                        }
+                        return r.json();
+                    })
                     .then(data => {
                         WMNGLoading.hide();
                         if (data.success) {
@@ -1429,7 +1465,15 @@
                     headers: baseHeaders,
                     body: JSON.stringify(payload),
                 })
-                .then(r => r.json())
+                .then(r => {
+                    // Surface non-2xx (403 admin gate, 419 CSRF, 500 server)
+                    // before trying to parse JSON — otherwise a HTML error page
+                    // throws an opaque SyntaxError and the real cause is lost.
+                    if (!r.ok) {
+                        throw new Error('HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : ''));
+                    }
+                    return r.json();
+                })
                 .then(data => {
                     WMNGLoading.hide();
                     if (data.success) {

--- a/src/Http/Controllers/MapController.php
+++ b/src/Http/Controllers/MapController.php
@@ -81,6 +81,11 @@ class MapController
                 'success' => true,
                 'message' => 'Map saved successfully',
             ]);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 400);
         } catch (\Exception $e) {
             return response()->json([
                 'success' => false,

--- a/src/Services/MapService.php
+++ b/src/Services/MapService.php
@@ -64,6 +64,21 @@ class MapService
 
     public function saveMap(Map $map, array $data): void
     {
+        // API validation: refuse to wipe an existing map when the payload is
+        // malformed (no "nodes"/"links" key at all). An intentional clear sends
+        // `nodes: []` / `links: []` explicitly; a missing key means the caller
+        // never populated them. This does NOT protect against the editor race
+        // (the client always sends both keys, even when empty) — that is the
+        // client-side load gate's job.
+        if (!array_key_exists('nodes', $data) || !array_key_exists('links', $data)) {
+            $existing = $map->links()->exists() || $map->nodes()->exists();
+            if ($existing) {
+                throw new \InvalidArgumentException(
+                    'Save payload missing "nodes" or "links" key; refusing to wipe existing map content.'
+                );
+            }
+        }
+
         try {
             DB::transaction(function () use ($map, $data) {
                 $this->updateMapProperties($map, $data);


### PR DESCRIPTION
## Problem

Issue #11 reported that clicking Save in the editor would silently wipe all nodes and links from the map. The root cause is a **destructive-save race**:

- The backend `saveMap()` → `replaceMapContent()` deletes all nodes/links then recreates from the client JS arrays.
- The editor loads existing data **asynchronously** via `GET /api/maps/{id}/json`.
- If the user clicked Save (or hit Ctrl+S) before that fetch resolved — or if it failed silently — the empty `nodes`/`links` arrays were POSTed and the map was **wiped**.

This explains all three reported symptoms: "click save, nothing happens" (save succeeds but wipes), "all links are gone" on the demo, "all items are gone" after reopen.

## Fix

### Client-side load gate (primary protection) — `editor.blade.php`
- Added `mapDataLoaded` / `mapDataLoadFailed` state flags. New maps start in the loaded state (nothing to load); existing maps start unloaded.
- `loadMapData()` checks `r.ok` before JSON parsing, sets `mapDataLoaded` only on successful population, sets `mapDataLoadFailed` on HTTP error / empty data / catch — with a visible toast so failures are no longer silent.
- `saveMap()` refuses to POST for an existing map until `mapDataLoaded` is true, with distinct messages for failed-load vs. still-loading. **Empty maps remain saveable after a successful load** — the gate is on load *completion*, not on `nodes.length`.
- Both the save and create fetch chains now check `r.ok` before `r.json()` so non-2xx responses (403 admin gate, 419 CSRF, 500 server) produce a meaningful `HTTP {status}` error instead of an opaque `SyntaxError`.

### Server-side API validation (defense-in-depth) — `MapService.php` + `MapController.php`
- `MapService::saveMap()` rejects payloads missing the `nodes` or `links` key entirely when the map already has content. An intentional Clear Canvas sends `nodes: []` / `links: []` explicitly and passes; a missing key means the caller never populated them. This is generic malformed-payload validation, not race protection — the client always sends both keys.
- `MapController::save()` returns **400** for `InvalidArgumentException` (malformed payload) and 500 for other exceptions.

## Verification
- JS syntax check on the extracted `<script>` block: `node --check` → exit 0.
- Diff inspection confirms `selectedNode` global preserved, gate flags wired correctly (`mapDataLoaded = true` only on success path), Clear Canvas unaffected.
- PHP unit tests not run — no PHP runtime in this environment. Recommend running `vendor/bin/phpunit` in a PHP 8.2+ environment before merge.

Closes #11