### PR TITLE
fix: node delete UI divergence and version restore crashes

### DIFF
--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -1639,8 +1639,20 @@ function deleteSelectedNode() {
             if (mapId && nodeToDelete.dbId) {
                 fetch('{{ url('plugin/WeathermapNG/map') }}' + '/' + mapId + '/node/' + nodeToDelete.dbId, {
                     method: 'DELETE',
-                    headers: { 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content }
-                }).then(() => finishDelete());
+                    headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+                }).then(r => {
+                    if (!r.ok) {
+                        throw new Error('HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : ''));
+                    }
+                    return r.json().catch(() => ({}));
+                }).then(data => {
+                    if (data.success === false) {
+                        throw new Error(data.message || 'Server refused to delete node');
+                    }
+                    finishDelete();
+                }).catch(err => {
+                    WMNGToast.error('Failed to delete node: ' + err.message, { duration: 3000 });
+                });
             } else {
                 // Node only exists locally
                 finishDelete();

--- a/src/Services/MapVersionService.php
+++ b/src/Services/MapVersionService.php
@@ -24,36 +24,63 @@ class MapVersionService
 
     public function restoreVersion(MapVersion $version): Map
     {
-        $snapshot = json_decode($version->config_snapshot, true);
+        $map = $version->map;
+        $mapId = $version->map_id;
 
-        if (isset($snapshot['nodes'])) {
-            foreach ($snapshot['nodes'] as $nodeData) {
-                if (isset($nodeData['id'])) {
-                    Node::where('id', $nodeData['id'])->update($nodeData);
-                } else {
-                    Node::create($nodeData);
-                }
-            }
+        // config_snapshot is cast to 'array' on the model, so $version->config_snapshot
+        // is already a PHP array. Handle both string and array defensively in case
+        // the cast is removed or the raw attribute is accessed via getRawOriginal().
+        $raw = $version->config_snapshot;
+        $snapshot = is_string($raw) ? json_decode($raw, true) : $raw;
+        if (!is_array($snapshot)) {
+            throw new \InvalidArgumentException('Version snapshot is corrupt or empty.');
         }
 
-        if (isset($snapshot['links'])) {
-            foreach ($snapshot['links'] as $linkData) {
-                if (isset($linkData['id'])) {
-                    Link::where('id', $linkData['id'])->update($linkData);
-                } else {
-                    Link::create($linkData);
+        return DB::transaction(function () use ($map, $mapId, $snapshot) {
+            if (isset($snapshot['nodes']) && is_array($snapshot['nodes'])) {
+                foreach ($snapshot['nodes'] as $nodeData) {
+                    if (isset($nodeData['id'])) {
+                        Node::where('id', $nodeData['id'])
+                            ->where('map_id', $mapId)
+                            ->update($nodeData);
+                    } else {
+                        Node::create(array_merge(['map_id' => $mapId], $nodeData));
+                    }
                 }
             }
-        }
 
-        $map->update([
-            'title' => $snapshot['map']['title'] ?? null,
-            'width' => $snapshot['map']['width'] ?? null,
-            'height' => $snapshot['map']['height'] ?? null,
-            'background' => $snapshot['map']['background'] ?? null,
-        ]);
+            if (isset($snapshot['links']) && is_array($snapshot['links'])) {
+                foreach ($snapshot['links'] as $linkData) {
+                    if (isset($linkData['id'])) {
+                        Link::where('id', $linkData['id'])
+                            ->where('map_id', $mapId)
+                            ->update($linkData);
+                    } else {
+                        Link::create(array_merge(['map_id' => $mapId], $linkData));
+                    }
+                }
+            }
 
-        return $map->fresh();
+            $map->update([
+                'title' => $snapshot['map']['title'] ?? null,
+            ]);
+            // width/height/background live in the options JSON column, not as
+            // top-level columns — merge them into options.
+            $options = $map->options ?? [];
+            if (isset($snapshot['map']['width'])) {
+                $options['width'] = $snapshot['map']['width'];
+            }
+            if (isset($snapshot['map']['height'])) {
+                $options['height'] = $snapshot['map']['height'];
+            }
+            if (isset($snapshot['map']['background'])) {
+                $options['background'] = $snapshot['map']['background'];
+            }
+            $map->options = $options;
+            $map->save();
+
+            return $map->fresh();
+        });
     }
 
     public function deleteVersionsOlderThan(MapVersion $version): void


### PR DESCRIPTION
## Background

A codebase-wide bug hunt (fanned out after PR #13) found four bugs in the same class as the issue #11 destructive-save race. This PR fixes the P1 and P2 items.

## P1 — `deleteSelectedNode` UI divergence (live)

`editor.blade.php`: The DELETE node handler called `.then(() => finishDelete())` with **no `r.ok` check and no `.catch`**. On a 403/419/500, the client still removed the node from local arrays while the server kept it — the editor UI diverged from the DB with no error shown to the user.

**Fix**: Now checks `r.ok`, parses the JSON response, verifies `success`, and only calls `finishDelete()` on success. Errors surface as a toast. Also switched the inline `document.querySelector` CSRF lookup to the `getCsrfToken()` helper (consistent with the save handler).

## P2 — `MapVersionService::restoreVersion` (latent — version routes currently unregistered)

`MapVersionService.php` had multiple bugs that would all crash or corrupt data if version routes are restored (per `VERSIONING.md`):

1. **Undefined `$map`** — `$map` was never assigned (only `$version` is a parameter); `$map->update()` would throw `Undefined variable $map` on every call. Now resolves via `$version->map`.
2. **Unscoped cross-map updates** — `Node::where('id', ...)->update()` and `Link::where('id', ...)->update()` were unscoped. A snapshot whose node/link IDs collide with rows on another map would mutate the wrong map's data. Now scoped with `->where('map_id', $mapId)`.
3. **`json_decode` on a cast array** — `config_snapshot` is cast to `array` on `MapVersion`, so `json_decode($version->config_snapshot, true)` would TypeError on the already-decoded array in PHP 8. Now handles both string and array: `is_string($raw) ? json_decode($raw, true) : $raw`.
4. **Orphaned creates** — `Node::create($nodeData)` and `Link::create($linkData)` did not set `map_id`, orphaning new rows. Now forces `map_id` via `array_merge(['map_id' => $mapId], ...)`.
5. **No transaction** — the restore was not wrapped in a DB transaction; a mid-restore failure would leave the map inconsistent. Now wrapped in `DB::transaction()`.
6. **Wrong column for dimensions** — `width`/`height`/`background` were written as top-level columns but they live in the `options` JSON column. Now merged into `options`.
7. **No snapshot validation** — a corrupt/empty `config_snapshot` would produce `null`, and the method would silently do nothing. Now throws `InvalidArgumentException`.

## Verification
- JS syntax check on extracted `<script>` block: `node --check` → exit 0.
- PHP unit tests not run — no PHP runtime in this environment. Recommend running `vendor/bin/phpunit` before merge.

## Remaining items (not in this PR)
- **P3**: 11 remaining `.then(r => r.json())` without `r.ok` across 7 blade files.
- **P4**: 4 broad-catch 500-instead-of-400 instances in controllers.
