### PR TITLE
fix: add r.ok checks and split validation errors to 400

### DIFF
--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -1249,7 +1249,10 @@
 
                 deviceSelect.innerHTML = '<option value="">Choose a device...</option>';
                 fetch('{{ url('plugin/WeathermapNG/api/devices') }}')
-                    .then(r => r.json())
+                    .then(r => {
+                        if (!r.ok) { console.warn('Failed to load devices: HTTP ' + r.status); return []; }
+                        return r.json();
+                    })
                     .then(data => {
                         const devices = Array.isArray(data) ? data : (data.devices || []);
                         devicesCache = devices;
@@ -1270,7 +1273,10 @@
                     }
                     if (interfaceContainer) interfaceContainer.style.display = 'block';
                     fetch(`{{ url('plugin/WeathermapNG/api/device') }}/${deviceId}/ports`)
-                        .then(r => r.json())
+                        .then(r => {
+                            if (!r.ok) { console.warn('Failed to load ports: HTTP ' + r.status); return { ports: [] }; }
+                            return r.json();
+                        })
                         .then(data => {
                             (data.ports || []).forEach(port => {
                                 const option = document.createElement('option');
@@ -1578,7 +1584,10 @@ function loadInterfacesForNode(node) {
     if (!node.deviceId) return;
 
     fetch('{{ url('plugin/WeathermapNG/api/device') }}/' + node.deviceId + '/ports')
-        .then(r => r.json())
+        .then(r => {
+            if (!r.ok) { console.warn('Failed to load interfaces: HTTP ' + r.status); return { ports: [] }; }
+            return r.json();
+        })
         .then(data => {
             (data.ports || []).forEach(port => {
                 const opt = document.createElement('option');
@@ -1597,8 +1606,13 @@ function saveSelectedNode() {
     const ifaceId = document.getElementById('node-prop-interface').value || null;
     const payload = { label: label, device_id: deviceId ? parseInt(deviceId, 10) : null, meta: { interface_id: ifaceId ? parseInt(ifaceId, 10) : null } };
     fetch('{{ url('plugin/WeathermapNG/map') }}' + '/' + mapId + '/node/' + selectedNode.dbId, {
-        method: 'PATCH', headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content }, body: JSON.stringify(payload)
-    }).then(r => r.json()).then(d => {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': getCsrfToken() }, body: JSON.stringify(payload)
+    }).then(r => {
+        if (!r.ok) {
+            throw new Error('HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : ''));
+        }
+        return r.json();
+    }).then(d => {
         if (d.success) {
             selectedNode.label = label;
             selectedNode.deviceId = payload.device_id;
@@ -1705,7 +1719,10 @@ function openLinkModal(linkIndex) {
     // Load source node ports
     if (srcNode && srcNode.deviceId) {
         fetch('{{ url('plugin/WeathermapNG/api/device') }}/' + srcNode.deviceId + '/ports')
-            .then(r => r.json())
+            .then(r => {
+                if (!r.ok) { console.warn('Failed to load source ports: HTTP ' + r.status); return { ports: [] }; }
+                return r.json();
+            })
             .then(data => {
                 (data.ports || []).forEach(port => {
                     const opt = document.createElement('option');
@@ -1720,7 +1737,10 @@ function openLinkModal(linkIndex) {
     // Load destination node ports
     if (dstNode && dstNode.deviceId) {
         fetch('{{ url('plugin/WeathermapNG/api/device') }}/' + dstNode.deviceId + '/ports')
-            .then(r => r.json())
+            .then(r => {
+                if (!r.ok) { console.warn('Failed to load destination ports: HTTP ' + r.status); return { ports: [] }; }
+                return r.json();
+            })
             .then(data => {
                 (data.ports || []).forEach(port => {
                     const opt = document.createElement('option');

--- a/resources/views/embed.blade.php
+++ b/resources/views/embed.blade.php
@@ -1131,9 +1131,12 @@
 
         function fetchMapData() {
             fetch(`${baseUrl}/plugin/WeathermapNG/api/maps/${mapId}/json`)
-                .then(response => response.json())
+                .then(response => {
+                    if (!response.ok) { console.warn('Map data fetch failed: HTTP ' + response.status); return null; }
+                    return response.json();
+                })
                 .then(data => {
-                    if (!data.error) {
+                    if (data && !data.error) {
                         mapData = data;
                         lastDataUpdate = Date.now();
                         renderMap();

--- a/resources/views/hooks/page.blade.php
+++ b/resources/views/hooks/page.blade.php
@@ -106,8 +106,12 @@
 document.addEventListener('DOMContentLoaded', function() {
     const refresh = () => {
         fetch('{{ url('plugin/WeathermapNG/health/stats') }}')
-            .then(r => r.json())
+            .then(r => {
+                if (!r.ok) { console.warn('Stats poll failed: HTTP ' + r.status); return null; }
+                return r.json();
+            })
             .then(d => {
+                if (!d) return;
                 const els = {
                     maps: document.querySelectorAll('h3')
                 };

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -775,7 +775,12 @@ $('#createMapForm').on('submit', function(e) {
             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
         }
     })
-    .then(response => response.json())
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + (response.statusText ? ' ' + response.statusText : ''));
+        }
+        return response.json();
+    })
     .then(data => {
         if (data.success) {
             WMNGToast.success('Map created successfully!');
@@ -823,7 +828,12 @@ $('#importMapForm').on('submit', function(e) {
             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
         }
     })
-    .then(response => response.json())
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + (response.statusText ? ' ' + response.statusText : ''));
+        }
+        return response.json();
+    })
     .then(data => {
         if (data.success) {
             WMNGToast.success('Map imported successfully!');

--- a/resources/views/install/index.blade.php
+++ b/resources/views/install/index.blade.php
@@ -182,7 +182,12 @@ function startInstallation() {
             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
         }
     })
-    .then(response => response.json())
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + (response.statusText ? ' ' + response.statusText : ''));
+        }
+        return response.json();
+    })
     .then(data => {
         spinner.classList.add('d-none');
 

--- a/resources/views/page.blade.php
+++ b/resources/views/page.blade.php
@@ -209,7 +209,12 @@ document.getElementById('confirmLegacyDeleteMapBtn')?.addEventListener('click', 
             'Content-Type': 'application/json',
         }
     })
-    .then(response => response.json())
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + (response.statusText ? ' ' + response.statusText : ''));
+        }
+        return response.json();
+    })
     .then(data => {
         if (data.success) {
             location.reload();
@@ -235,7 +240,12 @@ $('#createMapForm').on('submit', function(e) {
             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
         }
     })
-    .then(response => response.json())
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('HTTP ' + response.status + (response.statusText ? ' ' + response.statusText : ''));
+        }
+        return response.json();
+    })
     .then(data => {
         if (data.success) {
             $('#createMapModal').modal('hide');

--- a/src/Http/Controllers/InstallController.php
+++ b/src/Http/Controllers/InstallController.php
@@ -43,7 +43,12 @@ class InstallController extends Controller
                     'redirect' => url('plugin/WeathermapNG')
                 ]);
             }
-        } catch (Exception $e) {
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage()
+            ], 400);
+        } catch (\Exception $e) {
             return response()->json([
                 'success' => false,
                 'message' => 'Installation failed: ' . $e->getMessage()

--- a/src/Http/Controllers/MapController.php
+++ b/src/Http/Controllers/MapController.php
@@ -104,6 +104,11 @@ class MapController
                 'success' => true,
                 'message' => 'Auto-discovery completed',
             ]);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'success' => false,
+                'message' => $e->getMessage(),
+            ], 400);
         } catch (\Throwable $e) {
             return response()->json([
                 'success' => false,


### PR DESCRIPTION
## Background

A codebase-wide bug hunt (fanned out after PR #13/#14) found two classes of silent-error bugs. This PR fixes all P3 and P4 items.

## P3 — Silent fetch-error swallowing (11 sites across 6 blade files)

Every `.then(r => r.json())` without an `r.ok` guard would throw an opaque `SyntaxError` on a non-JSON error response (403/419/500 returning HTML), hiding the real HTTP status from the user. Fixed with the same pattern as PR #13 — check `r.ok` before parsing JSON.

**Per-file changes:**

- **`editor.blade.php`** (5 sites):
  - `loadDevices` — read-only, `r.ok` + `console.warn` + empty-array fallback
  - Device-select change port loader — read-only, same pattern
  - `loadInterfacesForNode` — read-only, same pattern
  - `saveSelectedNode` (mutating PATCH) — `r.ok` throws to existing `.catch` toast; also switched CSRF to `getCsrfToken()` helper (was `document.querySelector` that could throw if meta tag absent)
  - `openLinkModal` src+dst port loaders — read-only, `console.warn` + empty-array fallback

- **`embed.blade.php`** (1): `fetchMapData` poll — `response.ok` check with `console.warn` fallback, null-data guard in `.then`

- **`index.blade.php`** (2): `createMapForm` POST and `importMapForm` POST — `response.ok` throws `HTTP {status}` to existing `.catch` toast

- **`page.blade.php`** (2): legacy delete-map DELETE and create-map POST — `response.ok` throws to existing `.catch` alert

- **`hooks/page.blade.php`** (1): 30s stats poller — `r.ok` + `console.warn` + null-data guard

- **`install/index.blade.php`** (1): install run POST — `response.ok` throws to existing `.catch` error modal

**UX principle:** read-only/poll fetches use `console.warn` + graceful fallback (empty array or null) without user-facing toasts. Mutating fetches throw `HTTP {status}` to existing `.catch` handlers so the real error surfaces.

## P4 — Broad-catch 500-where-400-is-correct (2 controllers)

- **`MapController::autoDiscover`**: split `InvalidArgumentException` → 400 before the broad `Throwable` → 500 catch. `validateDiscoveryParams` throws `InvalidArgumentException` for bad input (was returned as 500).
- **`InstallController::install`**: split `InvalidArgumentException` → 400 before the broad `Exception` → 500 catch.
- **`RenderController::import`** and **`MapController::save`** already had the `InvalidArgumentException` → 400 split (the latter from PR #13) — no changes needed.

## Verification
- JS syntax check (`node --check`) on all extracted `<script>` blocks from all 6 touched blade files → all pass.
- Grep verified: no unguarded `.json()` patterns remain in `resources/views/` — every `.then(r => r.json())` is now preceded by an `r.ok` check.
- PHP unit tests not run — no PHP runtime in this environment. Recommend running `vendor/bin/phpunit` before merge.
