### PR TITLE
feat: NOC wall / kiosk mode for embed view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **NOC wall / kiosk mode** for embed view: add `?kiosk=1` to hide all chrome (nav, controls, legend, minimap, status bar), auto-hide the cursor, and reveal UI briefly on mouse/key activity. Press `Esc` to toggle chrome; click **Exit Kiosk** to return to the normal embed view.
+- **Map auto-cycling** in kiosk mode: add `?cycle=N` (minimum 5 seconds) to rotate through maps alphabetically. Cycle URLs preserve kiosk state and target settings.
+- **Configurable click-through target** in embed view: add `?target=self` to open node device pages and link port graphs in the same tab instead of a new tab.
+
 ## [1.8.0] - 2026-07-08
 
 ### Security

--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -18,6 +18,7 @@
 - **Pan & zoom**: Mouse-wheel zoom, drag-to-pan, +/-/Reset buttons, double-click zoom
 - **Hover tooltips**: Node In/Out/Sum traffic; link utilization, bandwidth
 - **Click navigation**: Click a node to open its device page; click a link to open port graphs
+- **Kiosk / NOC wall mode**: Hide all chrome, auto-cycle maps, and control click-through target (see below)
 
 ## Query Parameters
 
@@ -31,6 +32,9 @@
 | `nav` | `1` | Enable pan/zoom controls (`0` to disable) |
 | `minz` | `0.5` | Minimum zoom level |
 | `maxz` | `4` | Maximum zoom level |
+| `kiosk` | `0` | Enable NOC wall mode: hide nav, controls, legend, minimap, and status bar |
+| `cycle` | *(none)* | When `kiosk=1`, rotate to the next map every N seconds (minimum 5) |
+| `target` | `_blank` | Where node/link click-through opens: `_blank` (new tab) or `self` (same tab) |
 
 ## Live Data
 
@@ -52,9 +56,25 @@
 
 - PNG export composites background + overlay into a downloadable image
 
+## Kiosk / NOC Wall Mode
+
+Use `?kiosk=1` to turn the embed view into a clean wall display. All navigation, controls, legend, minimap, and status chrome is hidden. Move the mouse or press any key to briefly reveal chrome; press `Esc` to toggle chrome on/off. A small **Exit Kiosk** button appears in the bottom-right corner.
+
+Auto-cycle between maps with `?kiosk=1&cycle=30` (cycles every 30 seconds). Maps are visited in alphabetical order by name and the cycle URL preserves kiosk settings.
+
+### Examples
+
+- NOC wall rotating maps every 30 seconds:  
+  `plugin/WeathermapNG/embed/1?kiosk=1&cycle=30`
+- Static kiosk where clicks stay in the same tab:  
+  `plugin/WeathermapNG/embed/1?kiosk=1&target=self`
+- Static wall, no cycling:  
+  `plugin/WeathermapNG/embed/1?kiosk=1`
+
 ## Tips
 
 - Keep iframes sized to the map dimensions for crisp rendering
 - Use `metric=sum` to visualize total link load (in+out)
 - Use `nav=0` to disable pan/zoom for static dashboard widgets
 - Use `minz=0.5&maxz=2` to restrict zoom range for embedded views
+- Use `kiosk=1&target=self` in an iframe to keep navigation inside the parent dashboard

--- a/resources/views/embed.blade.php
+++ b/resources/views/embed.blade.php
@@ -196,6 +196,52 @@
             .embed-minimap { display: none; }
             .embed-controls { top: 80px; }
         }
+        /* Kiosk / NOC wall mode */
+        body.kiosk-mode .embed-nav-bar,
+        body.kiosk-mode .embed-controls,
+        body.kiosk-mode .embed-legend,
+        body.kiosk-mode .embed-minimap,
+        body.kiosk-mode .status-bar,
+        body.kiosk-mode #loading {
+            display: none !important;
+        }
+        body.kiosk-mode {
+            cursor: none;
+        }
+        body.kiosk-mode.show-chrome {
+            cursor: auto;
+        }
+        body.kiosk-mode.show-chrome .embed-nav-bar,
+        body.kiosk-mode.show-chrome .embed-controls,
+        body.kiosk-mode.show-chrome .embed-legend,
+        body.kiosk-mode.show-chrome .embed-minimap,
+        body.kiosk-mode.show-chrome .status-bar {
+            display: flex !important;
+        }
+        body.kiosk-mode.show-chrome .embed-legend,
+        body.kiosk-mode.show-chrome #loading {
+            display: block !important;
+        }
+        .kiosk-exit {
+            position: fixed;
+            bottom: 48px;
+            right: 10px;
+            z-index: 1002;
+            background: rgba(0,0,0,0.6);
+            color: #fff;
+            border: 0;
+            border-radius: 4px;
+            padding: 8px 12px;
+            font-size: 12px;
+            opacity: 0;
+            transition: opacity 0.3s ease;
+            pointer-events: none;
+        }
+        body.kiosk-mode .kiosk-exit,
+        body.kiosk-mode.show-chrome .kiosk-exit {
+            opacity: 1;
+            pointer-events: auto;
+        }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 </head>
@@ -260,6 +306,7 @@
             <div class="embed-legend-title">Legend</div>
             <div id="legend-rows"></div>
         </div>
+        <button type="button" id="kiosk-exit" class="kiosk-exit" aria-label="Exit kiosk mode">Exit Kiosk</button>
     </div>
 
     <script>
@@ -268,6 +315,10 @@
         const baseUrl = '{{ url("/") }}';
         const deviceBaseUrl = '{{ url("device") }}';
         const WMNG_CONFIG = {
+            kioskEnabled: {!! json_encode($kiosk) !!},
+            cycleSeconds: {!! json_encode($cycleSeconds) !!},
+            linkTarget: {!! json_encode($target) !!},
+            mapList: {!! json_encode($mapList ?? []) !!},
             thresholds: {!! json_encode(config('weathermapng.thresholds') ?? [50, 80, 95]) !!},
             colors: {
                 link_normal: '{{ config('weathermapng.colors.link_normal', '#28a745') }}',
@@ -339,6 +390,7 @@
         
         document.addEventListener('DOMContentLoaded', function() {
             initCanvas();
+            initKioskMode();
             // Sync flow toggle button with prefers-reduced-motion default
             const _flowBtn = document.getElementById('toggle-flow');
             if (_flowBtn && !flowAnimationEnabled) {
@@ -436,6 +488,57 @@
             // Update status and overlays
             updateStatus();
             drawMinimap();
+        }
+
+        function initKioskMode() {
+            if (!WMNG_CONFIG.kioskEnabled) return;
+
+            const body = document.body;
+            body.classList.add('kiosk-mode');
+            body.classList.add('show-chrome');
+
+            let activityTimer = null;
+            const hideChrome = () => body.classList.remove('show-chrome');
+            const showChrome = () => {
+                body.classList.add('show-chrome');
+                window.clearTimeout(activityTimer);
+                activityTimer = window.setTimeout(hideChrome, 3500);
+            };
+
+            document.addEventListener('mousemove', showChrome);
+            document.addEventListener('click', showChrome);
+            document.addEventListener('touchstart', showChrome);
+            document.addEventListener('keydown', (e) => {
+                if (e.key === 'Escape') {
+                    window.clearTimeout(activityTimer);
+                    body.classList.toggle('show-chrome');
+                    return;
+                }
+                showChrome();
+            });
+
+            const exitBtn = document.getElementById('kiosk-exit');
+            if (exitBtn) {
+                exitBtn.addEventListener('click', () => {
+                    window.location.href = window.location.pathname;
+                });
+            }
+
+            // Cycle to next map on a timer if requested.
+            const cycleSeconds = WMNG_CONFIG.cycleSeconds;
+            const mapList = WMNG_CONFIG.mapList || [];
+            if (cycleSeconds && mapList.length > 1) {
+                const currentId = String(mapId);
+                const idx = mapList.findIndex(m => String(m.id) === currentId);
+                const next = mapList[(idx + 1) % mapList.length];
+                if (next) {
+                    const nextUrl = new URL(window.location.pathname.replace(/\d+$/, String(next.id)) + window.location.search, window.location.origin);
+                    nextUrl.searchParams.set('kiosk', '1');
+                    nextUrl.searchParams.set('cycle', String(cycleSeconds));
+                    nextUrl.searchParams.set('target', WMNG_CONFIG.linkTarget === '_self' ? '_self' : '_blank');
+                    window.setTimeout(() => { window.location.assign(nextUrl.toString()); }, cycleSeconds * 1000);
+                }
+            }
         }
 
         function initNavControls() {
@@ -1399,7 +1502,7 @@
                     const did = n.device_id || n.deviceId || n.deviceid;
                     if (did) {
                         const url = deviceBaseUrl + '/' + did;
-                        window.open(url, '_blank');
+                        window.open(url, WMNG_CONFIG.linkTarget || '_blank');
                         return;
                     }
                 }
@@ -1432,7 +1535,7 @@
                     if (!portId) return;
                     const graphBaseUrl = '{{ url("graph") }}';
                     const url = graphBaseUrl + '?type=port_bits&id=' + portId + '&from=' + from + '&to=' + now;
-                    window.open(url, '_blank');
+                    window.open(url, WMNG_CONFIG.linkTarget || '_blank');
                 };
                 if (pA) openGraph(pA);
                 if (pB) openGraph(pB);

--- a/src/Http/Controllers/RenderController.php
+++ b/src/Http/Controllers/RenderController.php
@@ -43,7 +43,7 @@ class RenderController
         return response()->json($data);
     }
 
-    public function embed(Map $map): View
+    public function embed(Map $map, Request $request): View
     {
         $map->load(['nodes', 'links']);
         $this->nodeDataService->preloadForMap($map);
@@ -58,7 +58,30 @@ class RenderController
 
         $demoMode = config('weathermapng.demo_mode', false);
 
-        return view('WeathermapNG::embed', compact('mapData', 'mapId', 'liveData', 'demoMode'));
+        $kiosk = $request->boolean('kiosk');
+        $cycle = $request->input('cycle');
+        $cycleSeconds = ctype_digit((string) $cycle) ? max(5, (int) $cycle) : null;
+        $target = in_array($request->input('target'), ['self', '_self'], true) ? '_self' : '_blank';
+
+        // Ordered list of maps so kiosk mode can cycle without an extra API call.
+        $mapList = Map::query()
+            ->select(['id', 'name', 'title'])
+            ->orderBy('name')
+            ->get()
+            ->map(fn($m) => ['id' => $m->id, 'name' => $m->name, 'title' => $m->title])
+            ->values()
+            ->toArray();
+
+        return view('WeathermapNG::embed', compact(
+            'mapData',
+            'mapId',
+            'liveData',
+            'demoMode',
+            'kiosk',
+            'cycleSeconds',
+            'target',
+            'mapList'
+        ));
     }
 
     public function export(Map $map, Request $request): JsonResponse

--- a/tests/RenderControllerTest.php
+++ b/tests/RenderControllerTest.php
@@ -3,6 +3,7 @@
 namespace LibreNMS\Plugins\WeathermapNG\Tests;
 
 use LibreNMS\Plugins\WeathermapNG\Http\Controllers\RenderController;
+use LibreNMS\Plugins\WeathermapNG\Models\Map;
 use PHPUnit\Framework\TestCase;
 
 class RenderControllerTest extends TestCase
@@ -36,6 +37,15 @@ class RenderControllerTest extends TestCase
         $this->assertTrue(method_exists($this->controller, 'export'));
         $this->assertTrue(method_exists($this->controller, 'import'));
         $this->assertTrue(method_exists($this->controller, 'sse'));
+    }
+
+    public function test_embed_method_accepts_request_and_map_parameters(): void
+    {
+        $reflection = new \ReflectionMethod($this->controller, 'embed');
+        $params = $reflection->getParameters();
+        $this->assertCount(2, $params);
+        $this->assertEquals(Map::class, $params[0]->getType()?->getName());
+        $this->assertEquals(\Illuminate\Http\Request::class, $params[1]->getType()?->getName());
     }
 
     public function test_services_are_injected()

--- a/tests/UIEmbedKioskTest.php
+++ b/tests/UIEmbedKioskTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class UIEmbedKioskTest extends TestCase
+{
+    private string $content;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->content = file_get_contents(__DIR__ . '/../resources/views/embed.blade.php');
+    }
+
+    public function test_embed_passes_kiosk_config_to_js(): void
+    {
+        $this->assertStringContainsString("kioskEnabled: {!! json_encode(\$kiosk) !!}", $this->content);
+        $this->assertStringContainsString("cycleSeconds: {!! json_encode(\$cycleSeconds) !!}", $this->content);
+        $this->assertStringContainsString("linkTarget: {!! json_encode(\$target) !!}", $this->content);
+        $this->assertStringContainsString("mapList: {!! json_encode(\$mapList ?? []) !!}", $this->content);
+    }
+
+    public function test_embed_includes_kiosk_mode_styles(): void
+    {
+        $this->assertStringContainsString('body.kiosk-mode', $this->content);
+        $this->assertStringContainsString('body.kiosk-mode.show-chrome', $this->content);
+        $this->assertStringContainsString('.kiosk-exit', $this->content);
+    }
+
+    public function test_embed_includes_kiosk_cycle_logic(): void
+    {
+        $this->assertStringContainsString('function initKioskMode()', $this->content);
+        $this->assertStringContainsString('if (!WMNG_CONFIG.kioskEnabled) return;', $this->content);
+        $this->assertStringContainsString('window.setTimeout(() => { window.location.assign(nextUrl.toString()); }', $this->content);
+    }
+
+    public function test_embed_click_through_uses_configurable_target(): void
+    {
+        $this->assertStringContainsString("window.open(url, WMNG_CONFIG.linkTarget || '_blank');", $this->content);
+        $this->assertStringContainsString("window.open(url, WMNG_CONFIG.linkTarget || '_blank');", $this->content);
+    }
+
+    public function test_embed_has_kiosk_exit_button(): void
+    {
+        $this->assertStringContainsString('id="kiosk-exit"', $this->content);
+        $this->assertStringContainsString('aria-label="Exit kiosk mode"', $this->content);
+    }
+
+    public function test_embed_escape_keyhandler_does_not_show_chrome_before_toggle(): void
+    {
+        // The two listener pattern was: generic keydown => showChrome, then Escape handler toggles.
+        // That meant Escape always ended with chrome hidden. The fix registers one keydown listener
+        // where Escape clears the timer and toggles, and everything else calls showChrome().
+        $this->assertSame(
+            1,
+            substr_count($this->content, "addEventListener('keydown'"),
+            'Only one keydown listener should be registered in kiosk mode'
+        );
+        $this->assertMatchesRegularExpression(
+            "/if \(e\.key === 'Escape'\) \{[^}]+body\.classList\.toggle\('show-chrome'\);[^}]+return;[^}]+\}\s+showChrome\(\);/s",
+            $this->content,
+            'Escape must toggle show-chrome without first calling showChrome'
+        );
+    }
+
+    public function test_kiosk_exit_button_does_not_overlap_status_bar(): void
+    {
+        // The status bar is anchored bottom:10px; right:10px. The exit button must not share
+        // that corner to avoid overlap when chrome is revealed.
+        $this->assertStringContainsString('.kiosk-exit {', $this->content);
+        $this->assertStringNotContainsString(
+            '.kiosk-exit {'."\n".'            position: fixed;'."\n".'            bottom: 10px;'."\n".'            right: 10px;',
+            $this->content,
+            'kiosk-exit must avoid bottom:10px;right:10px status-bar corner'
+        );
+        preg_match('/\.kiosk-exit \{[^}]+bottom:\s*(\d+px);[^}]+\}/s', $this->content, $matches);
+        $this->assertNotEmpty($matches, 'kiosk-exit must declare a bottom offset');
+        $this->assertNotSame('10px', $matches[1], 'kiosk-exit bottom offset must differ from status-bar');
+    }
+}


### PR DESCRIPTION
Adds NOC wall / kiosk mode to the embed viewer.

- `?kiosk=1` hides nav, controls, legend, minimap, status bar; cursor auto-hides; chrome reappears on mouse/key/touch and toggles with Esc.
- `?cycle=N` (min 5s) auto-cycles through maps alphabetically.
- `?target=self` opens node device pages and link port graphs in the same tab instead of a new tab.
- Ordered map list is preloaded server-side so cycling has no async startup failure mode.

**Verification**
- PHPUnit: 220 tests, 745 assertions, OK (1 skipped).
- Container smoke: authenticated request to `/plugin/WeathermapNG/embed/16?kiosk=1&cycle=30&target=self` rendered HTML containing `kioskEnabled: true`, `cycleSeconds: 30`, `linkTarget: "_self"`, and a populated `mapList`.

**Files changed**
- `src/Http/Controllers/RenderController.php`
- `resources/views/embed.blade.php`
- `tests/UIEmbedKioskTest.php`
- `tests/RenderControllerTest.php`
- `docs/EMBED.md`
- `CHANGELOG.md`