### PR TITLE
feat: operational diagnostics page for admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Operational diagnostics page** for administrators: `/plugin/WeathermapNG/diagnostics` shows overall health, map/node/link counts, per-check status (database, filesystem, dependencies, configuration, performance), route registration, and writable-path checks. Linked from **Network Maps → Diagnostics** for admin users.
 - **NOC wall / kiosk mode** for embed view: add `?kiosk=1` to hide all chrome (nav, controls, legend, minimap, status bar), auto-hide the cursor, and reveal UI briefly on mouse/key activity. Press `Esc` to toggle chrome; click **Exit Kiosk** to return to the normal embed view.
 - **Map auto-cycling** in kiosk mode: add `?cycle=N` (minimum 5 seconds) to rotate through maps alphabetically. Cycle URLs preserve kiosk state and target settings.
 - **Configurable click-through target** in embed view: add `?target=self` to open node device pages and link port graphs in the same tab instead of a new tab.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -357,9 +357,22 @@ php artisan view:clear
 
 **Rollback.** To roll back to a previous version, `git checkout <tag>` in the plugin directory and re-run `composer install --no-dev && php artisan package:discover && php artisan optimize:clear`. Database tables from the newer version remain but are harmless — no down migrations are needed.
 
+## Diagnostics Page
+
+Administrators can open **Network Maps → Diagnostics** (or visit `/plugin/WeathermapNG/diagnostics`) to see a consolidated operational status panel:
+
+- Overall health status and plugin version
+- Map/node/link counts and estimated DB size
+- Per-check results for database, filesystem, dependencies, configuration, and performance
+- Registered-route status
+- Writable-path checks
+
+Use the diagnostics page as the first stop when something feels broken. If a route is shown as **Missing**, run `php artisan package:discover` and `php artisan route:clear`. If the database check fails, re-run `database/setup.php`. If a path is not writable, check that the plugin directory and `output/maps/` are owned by the LibreNMS runtime user.
+
 ## Verifying Installation
 
 1. Check the menu for "Network Maps" entry
 2. Visit `/plugin/WeathermapNG`
-3. Run `php artisan route:list | grep -iE 'weathermap|wmng'`
-4. Try creating a test map
+3. As an admin, visit **Network Maps → Diagnostics** and confirm all checks are healthy
+4. Run `php artisan route:list | grep -iE 'weathermap|wmng'`
+5. Try creating a test map

--- a/resources/views/diagnostics.blade.php
+++ b/resources/views/diagnostics.blade.php
@@ -1,0 +1,132 @@
+@extends('layouts.librenmsv1')
+
+@section('title', 'WeathermapNG Diagnostics')
+
+@section('content')
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <h2>WeathermapNG Diagnostics</h2>
+            <p class="text-muted">Operational status for administrators.</p>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="alert alert-{{ $overallStatus === 'healthy' ? 'success' : ($overallStatus === 'warning' ? 'warning' : 'danger') }}" role="alert">
+                <strong>Overall:</strong> {{ ucfirst($overallStatus) }}
+                <span class="float-end text-muted">Plugin v{{ $version }}</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-4">
+            <div class="card">
+                <div class="card-header">Counts</div>
+                <div class="card-body">
+                    <table class="table table-sm table-borderless mb-0">
+                        <tr><td>Maps</td><td class="text-end">{{ $stats['maps'] ?? 0 }}</td></tr>
+                        <tr><td>Nodes</td><td class="text-end">{{ $stats['nodes'] ?? 0 }}</td></tr>
+                        <tr><td>Links</td><td class="text-end">{{ $stats['links'] ?? 0 }}</td></tr>
+                        <tr><td>DB size</td><td class="text-end">{{ $stats['database_size'] ?? 'Unknown' }}</td></tr>
+                    </table>
+                    @if(!empty($stats['error']))
+                        <div class="text-danger small mt-2">{{ $stats['error'] }}</div>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-8">
+            <div class="card">
+                <div class="card-header">Health Checks</div>
+                <div class="card-body">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr><th>Check</th><th>Status</th><th>Message</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach($checks as $name => $check)
+                            <tr>
+                                <td>{{ ucfirst($name) }}</td>
+                                <td>
+                                    <span class="badge bg-{{ ($check['status'] ?? 'unknown') === 'healthy' ? 'success' : (($check['status'] ?? 'unknown') === 'warning' ? 'warning' : 'danger') }}">
+                                        {{ ucfirst($check['status'] ?? 'unknown') }}
+                                    </span>
+                                </td>
+                                <td>{{ $check['message'] ?? '-' }}</td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">Routes</div>
+                <div class="card-body p-0">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr><th>Method</th><th>Name</th><th>Status</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach($routes as $route)
+                            <tr>
+                                <td>{{ $route['method'] }}</td>
+                                <td>
+                                    @if($route['url'] !== '#')
+                                        <a href="{{ $route['url'] }}">{{ $route['name'] }}</a>
+                                    @else
+                                        <span class="text-muted">{{ $route['name'] }}</span>
+                                    @endif
+                                </td>
+                                <td>
+                                    <span class="badge bg-{{ $route['status'] === 'ok' ? 'success' : 'danger' }}">
+                                        {{ $route['status'] === 'ok' ? 'OK' : 'Missing' }}
+                                    </span>
+                                </td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">Writable Paths</div>
+                <div class="card-body p-0">
+                    <table class="table table-sm mb-0">
+                        <thead>
+                            <tr><th>Path</th><th>Exists</th><th>Writable</th></tr>
+                        </thead>
+                        <tbody>
+                            @foreach($paths as $label => $path)
+                            <tr>
+                                <td><code>{{ $path['path'] }}</code></td>
+                                <td>
+                                    <span class="badge bg-{{ $path['exists'] ? 'success' : 'danger' }}">
+                                        {{ $path['exists'] ? 'Yes' : 'No' }}
+                                    </span>
+                                </td>
+                                <td>
+                                    <span class="badge bg-{{ $path['writable'] ? 'success' : 'warning' }}">
+                                        {{ $path['writable'] ? 'Yes' : 'No' }}
+                                    </span>
+                                </td>
+                            </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/menu.blade.php
+++ b/resources/views/menu.blade.php
@@ -2,5 +2,14 @@
     <a href="{{ $url }}" class="nav-link">
         <i class="fas {{ $icon ?? 'fa-map' }}"></i>
         <span>{{ $title }}</span>
+        @if(($map_count ?? 0) > 0)
+            <span class="badge bg-primary float-end">{{ $map_count }}</span>
+        @endif
     </a>
+    @if($is_admin ?? false)
+        <a href="{{ $diagnostics_url }}" class="nav-link">
+            <i class="fas fa-stethoscope"></i>
+            <span>Diagnostics</span>
+        </a>
+    @endif
 </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,7 @@ Route::middleware(['web', 'auth'])->group(function () {
     Route::get('plugin/WeathermapNG/health/detailed', [HealthController::class, 'detailed'])->name('weathermapng.health.detailed');
     Route::get('plugin/WeathermapNG/health/stats', [HealthController::class, 'stats'])->name('weathermapng.health.stats');
     Route::get('plugin/WeathermapNG/metrics', [HealthController::class, 'metrics'])->name('weathermapng.metrics');
+    Route::get('plugin/WeathermapNG/diagnostics', [HealthController::class, 'diagnostics'])->name('weathermapng.diagnostics');
 });
 
 Route::prefix('plugin/WeathermapNG')->group(function () {

--- a/src/Hooks/MenuEntry.php
+++ b/src/Hooks/MenuEntry.php
@@ -27,12 +27,27 @@ class MenuEntry implements MenuEntryHook
             // Tables might not exist yet
         }
 
+        // Determine admin status using the same fallbacks as AdminCheck
+        $user = auth()->user();
+        $isAdmin = false;
+        if ($user) {
+            if ((method_exists($user, 'hasGlobalAdmin') && $user->hasGlobalAdmin())
+                || (method_exists($user, 'isAdmin') && $user->isAdmin())
+                || (isset($user->level) && $user->level >= 10)
+                || (method_exists($user, 'hasRole') && $user->hasRole('admin'))
+            ) {
+                $isAdmin = true;
+            }
+        }
+
         // Return view name with plugin namespace and data
         return ["{$pluginName}::menu", [
             'title' => 'Network Maps',
             'url' => url('plugin/WeathermapNG'),
             'icon' => 'fa-network-wired',
-            'badge' => $mapCount > 0 ? $mapCount : null,
+            'map_count' => $mapCount > 0 ? $mapCount : null,
+            'is_admin' => $isAdmin,
+            'diagnostics_url' => url('plugin/WeathermapNG/diagnostics'),
         ]];
     }
 }

--- a/src/Http/Controllers/HealthController.php
+++ b/src/Http/Controllers/HealthController.php
@@ -9,6 +9,7 @@ use LibreNMS\Plugins\WeathermapNG\Services\DevicePortLookup;
 use LibreNMS\Plugins\WeathermapNG\Services\Logger;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
 
 class HealthController
 {
@@ -177,6 +178,89 @@ class HealthController
      * Prometheus metrics endpoint
      * GET /plugin/WeathermapNG/metrics
      */
+    public function diagnostics(): \Illuminate\View\View
+    {
+        $this->requireAdmin();
+
+        $health = $this->check()->getData(true);
+
+        $stats = [
+            'maps' => 0,
+            'nodes' => 0,
+            'links' => 0,
+            'database_size' => 'Unknown',
+        ];
+        try {
+            $stats['maps'] = Map::count();
+            $stats['nodes'] = DB::table('wmng_nodes')->count();
+            $stats['links'] = DB::table('wmng_links')->count();
+            $stats['database_size'] = $this->getDatabaseSize();
+        } catch (\Exception $e) {
+            $stats['error'] = 'Unable to query statistics: ' . $e->getMessage();
+        }
+
+        $checks = [
+            'database' => $this->checkDatabase(),
+            'filesystem' => $this->checkFilesystem(),
+            'dependencies' => $this->checkDependencies(),
+            'configuration' => $this->checkConfiguration(),
+            'performance' => $this->getPerformanceMetrics(),
+        ];
+
+        $routes = [
+            ['name' => 'Index', 'route' => 'weathermapng.index', 'method' => 'GET', 'url' => route('weathermapng.index')],
+            ['name' => 'Embed', 'route' => 'weathermapng.embed', 'method' => 'GET'],
+            ['name' => 'Map JSON', 'route' => 'weathermapng.json', 'method' => 'GET'],
+            ['name' => 'Live data', 'route' => 'weathermapng.live', 'method' => 'GET'],
+            ['name' => 'Save map', 'route' => 'weathermapng.map.save', 'method' => 'POST'],
+            ['name' => 'Health check', 'route' => 'weathermapng.health', 'method' => 'GET', 'url' => route('weathermapng.health')],
+            ['name' => 'Health detailed', 'route' => 'weathermapng.health.detailed', 'method' => 'GET', 'url' => route('weathermapng.health.detailed')],
+            ['name' => 'Health stats', 'route' => 'weathermapng.health.stats', 'method' => 'GET', 'url' => route('weathermapng.health.stats')],
+            ['name' => 'Metrics', 'route' => 'weathermapng.metrics', 'method' => 'GET', 'url' => route('weathermapng.metrics')],
+            ['name' => 'Diagnostics', 'route' => 'weathermapng.diagnostics', 'method' => 'GET', 'url' => route('weathermapng.diagnostics')],
+        ];
+
+        $routeStatus = array_map(function ($r) {
+            if (!Route::has($r['route'])) {
+                $r['url'] = '#';
+                $r['status'] = 'missing';
+                return $r;
+            }
+            // Parameterized routes are registered; don't try to synthesize a URL.
+            if (!isset($r['url'])) {
+                $r['url'] = '#';
+            }
+            $r['status'] = 'ok';
+            return $r;
+        }, $routes);
+
+        $writablePaths = [
+            'output/maps' => config('weathermapng.output_dir', __DIR__ . '/../../../output/maps/'),
+            'resources/output' => __DIR__ . '/../../../resources/output/',
+            'storage' => __DIR__ . '/../../../storage/',
+        ];
+
+        $pathStatus = [];
+        foreach ($writablePaths as $label => $path) {
+            $resolved = realpath($path) ?: $path;
+            $pathStatus[$label] = [
+                'path' => $resolved,
+                'exists' => is_dir($resolved),
+                'writable' => is_writable($resolved),
+            ];
+        }
+
+        return view('WeathermapNG::diagnostics', [
+            'version' => $this->getVersion(),
+            'overallStatus' => $health['status'] ?? 'unknown',
+            'checks' => $checks,
+            'stats' => $stats,
+            'routes' => $routeStatus,
+            'paths' => $pathStatus,
+            'librenmsVersion' => config('librenms.version', 'unknown'),
+        ]);
+    }
+
     public function metrics(): \Illuminate\Http\Response
     {
         $this->requireAdmin();

--- a/tests/DiagnosticsTest.php
+++ b/tests/DiagnosticsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class DiagnosticsTest extends TestCase
+{
+    private string $controller;
+    private string $view;
+    private string $routes;
+    private string $menuHook;
+    private string $menuBlade;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->controller = file_get_contents(__DIR__ . '/../src/Http/Controllers/HealthController.php');
+        $this->view = file_get_contents(__DIR__ . '/../resources/views/diagnostics.blade.php');
+        $this->routes = file_get_contents(__DIR__ . '/../routes/web.php');
+        $this->menuHook = file_get_contents(__DIR__ . '/../src/Hooks/MenuEntry.php');
+        $this->menuBlade = file_get_contents(__DIR__ . '/../resources/views/menu.blade.php');
+    }
+
+    public function test_diagnostics_route_is_registered(): void
+    {
+        $this->assertStringContainsString("Route::get('plugin/WeathermapNG/diagnostics'", $this->routes);
+        $this->assertStringContainsString("'weathermapng.diagnostics'", $this->routes);
+    }
+
+    public function test_diagnostics_method_exists_and_requires_admin(): void
+    {
+        $this->assertStringContainsString('public function diagnostics(): \\Illuminate\\View\\View', $this->controller);
+
+        $start = strpos($this->controller, 'public function diagnostics()');
+        $end = strpos($this->controller, 'public function metrics()', $start);
+        $body = substr($this->controller, $start, $end - $start);
+        $this->assertStringContainsString('$this->requireAdmin();', $body);
+    }
+
+    public function test_diagnostics_uses_route_has_for_status(): void
+    {
+        $this->assertStringContainsString('Route::has($r[\'route\'])', $this->controller);
+        $this->assertStringContainsString("if (!isset(\$r['url'])) {", $this->controller);
+        $this->assertStringContainsString("\$r['url'] = '#'", $this->controller);
+    }
+
+    public function test_diagnostics_view_renders(): void
+    {
+        foreach (['Overall', 'Counts', 'Health Checks', 'Routes', 'Writable Paths'] as $section) {
+            $this->assertStringContainsString($section, $this->view);
+        }
+        $this->assertStringContainsString('$overallStatus', $this->view);
+        $this->assertStringContainsString('$checks', $this->view);
+        $this->assertStringContainsString('$stats', $this->view);
+        $this->assertStringContainsString('$routes', $this->view);
+        $this->assertStringContainsString('$paths', $this->view);
+    }
+
+    public function test_diagnostics_view_does_not_link_missing_routes(): void
+    {
+        $this->assertStringContainsString("@if(\$route['url'] !== '#')", $this->view);
+        $this->assertStringContainsString("<span class=\"text-muted\">{{ \$route['name'] }}</span>", $this->view);
+    }
+
+    public function test_menu_hook_passes_admin_flag_and_diagnostics_url(): void
+    {
+        $this->assertStringContainsString("'is_admin' => \$isAdmin", $this->menuHook);
+        $this->assertStringContainsString("'diagnostics_url'", $this->menuHook);
+    }
+
+    public function test_menu_blade_shows_diagnostics_link_for_admins(): void
+    {
+        $this->assertStringContainsString("@if(\$is_admin ?? false)", $this->menuBlade);
+        $this->assertStringContainsString("{{ \$diagnostics_url }}", $this->menuBlade);
+        $this->assertStringContainsString('fa-stethoscope', $this->menuBlade);
+    }
+}


### PR DESCRIPTION
Adds an admin-only diagnostics page at `/plugin/WeathermapNG/diagnostics`.

- Aggregates health checks, map/node/link counts, DB size, route registration, and writable-path status.
- Uses `Route::has()` to verify route registration without synthesizing URLs for parameterized routes.
- Adds a **Diagnostics** link under the Network Maps menu hook for admins.
- Uses `layouts.librenmsv1` for consistency with other plugin pages.

**Verification**
- PHPUnit: 228 tests, 773 assertions, OK (1 skipped).
- Container smoke: authenticated `GET /plugin/WeathermapNG/diagnostics` returned 200 with all expected sections (Counts, Health Checks, Routes, Writable Paths); unauthenticated returned 302.

**Files changed**
- `src/Http/Controllers/HealthController.php`
- `src/Hooks/MenuEntry.php`
- `resources/views/diagnostics.blade.php`
- `resources/views/menu.blade.php`
- `routes/web.php`
- `tests/DiagnosticsTest.php`
- `docs/INSTALL.md`
- `CHANGELOG.md`