### PR TITLE
feat: map tags, filtering, and first-run onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Map tags and filtering**: assign lowercase tags to maps from the editor; tags are stored in `wmng_maps.options`. The index view shows tag chips on each card and a tag filter dropdown. Tags are normalized, trimmed, and deduplicated on save.
+- **First-run onboarding**: when no maps exist, the index view now shows links to Templates, Create Custom Map, Import Map, Diagnostics, and Docs instead of only a create button.
 - **Operational diagnostics page** for administrators: `/plugin/WeathermapNG/diagnostics` shows overall health, map/node/link counts, per-check status (database, filesystem, dependencies, configuration, performance), route registration, and writable-path checks. Linked from **Network Maps → Diagnostics** for admin users.
 - **NOC wall / kiosk mode** for embed view: add `?kiosk=1` to hide all chrome (nav, controls, legend, minimap, status bar), auto-hide the cursor, and reveal UI briefly on mouse/key activity. Press `Esc` to toggle chrome; click **Exit Kiosk** to return to the normal embed view.
 - **Map auto-cycling** in kiosk mode: add `?cycle=N` (minimum 5 seconds) to rotate through maps alphabetically. Cycle URLs preserve kiosk state and target settings.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ A modern network weathermap plugin for LibreNMS that provides real-time network 
 - **Import/Export**: JSON format for backup and sharing maps
 - **Embed Support**: Embed maps in dashboards with live updates
 - **Map Templates**: Built-in templates for common network topologies
-- **Map Versioning Foundation**: Snapshot storage and history services for map rollback workflows (routes not yet registered — see [VERSIONING.md](VERSIONING.md))
+- **Map Tags & Filtering**: Organize maps with tags from the editor and filter the index gallery by tag
+- **Operational Diagnostics**: Admin page with health checks, route registration, writable paths, and resource counts
+- **Map Versioning**: Snapshot storage, history, restore, compare, and delete workflows
 
 ## Quick Start
 
@@ -61,10 +63,11 @@ See [INSTALL.md](INSTALL.md) for details and sample topologies.
 ### First Map
 
 1. **Open the plugin** at `https://your-librenms/plugin/WeathermapNG`
-2. **Create a map** — click "Create New Map" or pick a template
-3. **Configure** the name, title, and dimensions
+2. **Create a map** — click "Create New Map", pick a template, or import an existing map
+3. **Configure** the name, title, dimensions, and tags
 4. **Design** in the canvas editor: add devices from the right sidebar, drag to position, draw links between nodes
 5. **Save** — your map is live with real-time traffic data
+6. **Troubleshoot** via the admin **Diagnostics** page if anything looks off
 
 ### Requirements
 

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -101,6 +101,18 @@
 }
 .editor-sidebar .panel-body { padding: 10px 12px; }
 .editor-sidebar .form-label { font-size: 11px; margin-bottom: 2px; color: var(--editor-text-muted); }
+.editor-tag {
+    display: inline-block;
+    font-size: 11px;
+    background: var(--editor-panel-header-bg);
+    color: var(--editor-text-muted);
+    border: 1px solid var(--editor-sidebar-border);
+    border-radius: 12px;
+    padding: 2px 8px;
+    margin: 0 4px 4px 0;
+    text-transform: lowercase;
+}
+.map-tags-preview { margin-top: 6px; }
 .editor-sidebar .form-control-sm {
     font-size: 12px; background: var(--editor-input-bg); border-color: var(--editor-input-border);
     color: var(--editor-input-text);
@@ -326,6 +338,13 @@
                         <input type="number" class="form-control form-control-sm" id="map-height"
                                value="{{ $map->height ?? config('weathermapng.default_height', 600) }}" min="100" max="4096">
                     </div>
+                </div>
+                <div class="form-group mb-2">
+                    <label class="form-label" for="map-tags">Tags</label>
+                    <input type="text" class="form-control form-control-sm" id="map-tags"
+                           value="{{ implode(', ', $map->tags ?? []) }}" placeholder="e.g. core, wan, datacenter">
+                    <small class="text-muted">Comma-separated letters, numbers, hyphens, underscores</small>
+                    <div id="map-tags-preview" class="map-tags-preview"></div>
                 </div>
             </div>
         </div>
@@ -582,6 +601,28 @@
 
             // Escape user-controlled strings before interpolating into innerHTML (XSS hardening).
             function escapeHtml(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
+
+            function parseMapTags(raw) {
+                if (typeof raw !== 'string' || !raw.trim()) return [];
+                const tags = raw.split(',')
+                    .map(t => t.trim().toLowerCase())
+                    .filter(t => /^[a-z0-9_-]+$/.test(t));
+                return Array.from(new Set(tags));
+            }
+
+            function renderMapTagsPreview(tags) {
+                const el = document.getElementById('map-tags-preview');
+                if (!el) return;
+                if (!Array.isArray(tags) || tags.length === 0) {
+                    el.innerHTML = '';
+                    return;
+                }
+                el.innerHTML = tags.map(t => `<span class="editor-tag">${escapeHtml(t)}</span>`).join(' ');
+            }
+
+            document.getElementById('map-tags')?.addEventListener('input', (e) => {
+                renderMapTagsPreview(parseMapTags(e.target.value));
+            });
 
             function initCanvas() {
                 canvas = document.getElementById('map-canvas');
@@ -1281,6 +1322,12 @@
                     if (mapWidth && data.width) mapWidth.value = data.width;
                     if (mapHeight && data.height) mapHeight.value = data.height;
 
+                    const mapTags = document.getElementById('map-tags');
+                    if (mapTags && Array.isArray(data.options?.tags)) {
+                        mapTags.value = data.options.tags.join(', ');
+                        renderMapTagsPreview(data.options.tags);
+                    }
+
                     if (data.width && canvas) canvas.width = data.width;
                     if (data.height && canvas) canvas.height = data.height;
 
@@ -1503,6 +1550,7 @@
                     options: {
                         width: mapWidth,
                         height: mapHeight,
+                        tags: parseMapTags(document.getElementById('map-tags')?.value),
                     },
                     nodes: nodes.map(n => ({
                         id: n.id,

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -132,6 +132,32 @@
 }
 .wmng-filters #map-search { width: 280px; }
 .wmng-filters #map-filter { width: 180px; }
+.wmng-filters #map-tag-filter { width: 180px; }
+
+.map-tags {
+    display: flex;
+    gap: 0.35rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+.map-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--idx-text-muted);
+    background: var(--idx-stat-bg);
+    border: 1px solid var(--idx-stat-border);
+    border-radius: 12px;
+    padding: 0.2rem 0.6rem;
+    text-transform: lowercase;
+}
+.map-tag.active {
+    background: #667eea;
+    color: #fff;
+    border-color: #667eea;
+}
 
 
 /* ===== Map Cards ===== */
@@ -278,8 +304,14 @@
     margin-bottom: 0.5rem;
 }
 .wmng-empty p {
-    max-width: 400px;
+    max-width: 500px;
     margin: 0 auto 1.5rem;
+}
+.wmng-onboarding-actions {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
 }
 
 /* ===== Alerts ===== */
@@ -434,6 +466,14 @@
                     <option value="links-desc">Most links</option>
                     <option value="size-desc">Largest</option>
                 </select>
+                <select class="form-control" id="map-tag-filter" aria-label="Filter by tag">
+                    <option value="">All tags</option>
+                    @foreach(collect($maps)->flatMap(fn($m) => $m->tags)->unique()->sort()->values() as $tag)
+                        @if($tag !== '')
+                            <option value="{{ $tag }}">{{ $tag }}</option>
+                        @endif
+                    @endforeach
+                </select>
             </div>
         </div>
 
@@ -459,7 +499,8 @@
                      data-title="{{ strtolower($map->title ?? $map->name) }}"
                      data-nodes="{{ $map->nodes_count ?? $map->nodes()->count() }}"
                      data-links="{{ $map->links_count ?? $map->links()->count() }}"
-                     data-size="{{ ($map->width ?? 0) * ($map->height ?? 0) }}">
+                     data-size="{{ ($map->width ?? 0) * ($map->height ?? 0) }}"
+                     data-tags="{{ json_encode($map->tags) }}">
                     <div class="map-card">
                         <div class="map-card-preview">
                             <div class="map-card-dimensions">
@@ -482,6 +523,13 @@
                                     {{ $map->links_count ?? $map->links()->count() }} links
                                 </span>
                             </div>
+                            @if(count($map->tags) > 0)
+                                <div class="map-tags" aria-label="Map tags">
+                                    @foreach($map->tags as $tag)
+                                        <span class="map-tag" data-tag="{{ $tag }}">{{ $tag }}</span>
+                                    @endforeach
+                                </div>
+                            @endif
                             <div class="map-card-meta">
                                 <i class="fas fa-clock" aria-hidden="true"></i>
                                 Updated {{ $map->updated_at ? $map->updated_at->diffForHumans() : 'recently' }}
@@ -519,11 +567,29 @@
                             <i class="fas fa-map-marked-alt" aria-hidden="true"></i>
                         </div>
                         <h3>No maps yet</h3>
-                        <p>Create your first network map to visualize your infrastructure with real-time traffic data.</p>
-                        <button type="button" class="btn btn-success btn-lg" data-toggle="modal" data-target="#createMapModal"
-                                aria-label="Create your first map">
-                            <i class="fas fa-plus mr-2" aria-hidden="true"></i>Create Your First Map
-                        </button>
+                        <p>Get started by creating a map from a template, importing an existing map, or building a custom topology. If the plugin is fresh, run the diagnostics page first.</p>
+                        <div class="wmng-onboarding-actions">
+                            <a href="{{ url('plugin/WeathermapNG/templates') }}" class="btn btn-success btn-lg"
+                               aria-label="Browse map templates">
+                                <i class="fas fa-th-large mr-2" aria-hidden="true"></i>Browse Templates
+                            </a>
+                            <button type="button" class="btn btn-outline-secondary btn-lg" data-toggle="modal" data-target="#createMapModal"
+                                    aria-label="Create your first map">
+                                <i class="fas fa-plus mr-2" aria-hidden="true"></i>Create Custom Map
+                            </button>
+                            <button type="button" class="btn btn-outline-secondary btn-lg" data-toggle="modal" data-target="#importMapModal"
+                                    aria-label="Import an existing map">
+                                <i class="fas fa-file-import mr-2" aria-hidden="true"></i>Import Map
+                            </button>
+                            <a href="{{ url('plugin/WeathermapNG/diagnostics') }}" class="btn btn-outline-info btn-lg"
+                               aria-label="Open diagnostics">
+                                <i class="fas fa-stethoscope mr-2" aria-hidden="true"></i>Diagnostics
+                            </a>
+                            <a href="https://github.com/lance0/weathermapNG/blob/main/docs/EMBED.md" class="btn btn-outline-primary btn-lg" target="_blank" rel="noopener noreferrer"
+                               aria-label="Read embed documentation">
+                                <i class="fas fa-book mr-2" aria-hidden="true"></i>Docs
+                            </a>
+                        </div>
                     </div>
                 </div>
             @endforelse
@@ -869,11 +935,20 @@ document.getElementById('confirmDeleteMapBtn')?.addEventListener('click', functi
 document.addEventListener('DOMContentLoaded', function() {
     const searchInput = document.getElementById('map-search');
     const filterSelect = document.getElementById('map-filter');
+    const tagFilter = document.getElementById('map-tag-filter');
     const container = document.getElementById('maps-container');
     if (!searchInput || !filterSelect || !container) return;
 
     const cards = Array.from(container.querySelectorAll('.map-card-col'));
     const total = cards.length;
+
+    function getCardTags(card) {
+        try {
+            return JSON.parse(card.dataset.tags || '[]');
+        } catch (e) {
+            return [];
+        }
+    }
 
     function sortCards(mode) {
         const sorted = [...cards].sort((a, b) => {
@@ -900,11 +975,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function applyFilter() {
         const query = searchInput.value.trim().toLowerCase();
+        const selectedTag = tagFilter ? tagFilter.value.trim().toLowerCase() : '';
         let visible = 0;
 
         cards.forEach(card => {
             const text = `${card.dataset.name} ${card.dataset.title}`;
-            const isMatch = text.includes(query);
+            const textMatch = text.includes(query);
+            const tagMatch = !selectedTag || getCardTags(card).includes(selectedTag);
+            const isMatch = textMatch && tagMatch;
             card.style.display = isMatch ? '' : 'none';
             if (isMatch) visible += 1;
         });
@@ -919,6 +997,9 @@ document.addEventListener('DOMContentLoaded', function() {
     filterSelect.addEventListener('change', function() {
         sortCards(this.value);
     });
+    if (tagFilter) {
+        tagFilter.addEventListener('change', applyFilter);
+    }
 
     sortCards(filterSelect.value);
     applyFilter();

--- a/src/Http/Requests/SaveMapRequest.php
+++ b/src/Http/Requests/SaveMapRequest.php
@@ -21,6 +21,8 @@ class SaveMapRequest extends FormRequest
             'options.width' => 'nullable|integer|min:100|max:4096',
             'options.height' => 'nullable|integer|min:100|max:4096',
             'options.background' => 'nullable|string|max:20|regex:/^#[0-9a-fA-F]{6}$/',
+            'options.tags' => 'nullable|array|max:50',
+            'options.tags.*' => 'nullable|string|max:50|regex:/^[a-z0-9_-]+$/i',
 
             // Keys must be present (empty arrays are intentional clears).
             'nodes' => 'required|array|max:2000',
@@ -65,6 +67,9 @@ class SaveMapRequest extends FormRequest
             'options.height.min' => 'Height must be at least 100 pixels',
             'options.height.max' => 'Height must not exceed 4096 pixels',
             'options.background.regex' => 'Background must be a valid hex color (e.g., #ffffff)',
+            'options.tags.max' => 'A map cannot have more than 50 tags',
+            'options.tags.*.max' => 'Each tag must not exceed 50 characters',
+            'options.tags.*.regex' => 'Tags may only contain letters, numbers, hyphens and underscores',
             'links.*.style.array' => 'Link style may only contain via_style and via_points',
             'links.*.style.via_style.in' => 'Via style must be straight, angled, or curved',
             'links.*.style.via_points.*.x.numeric' => 'Via point x must be numeric',
@@ -117,6 +122,12 @@ class SaveMapRequest extends FormRequest
     {
         if (isset($data['title']) && is_string($data['title'])) {
             $data['title'] = strip_tags($data['title']);
+        }
+
+        if (!empty($data['options']['tags']) && is_array($data['options']['tags'])) {
+            $tags = array_map(fn($t) => is_string($t) ? strtolower(strip_tags(trim($t))) : '', $data['options']['tags']);
+            $tags = array_values(array_unique(array_filter($tags, fn($t) => $t !== '')));
+            $data['options']['tags'] = $tags;
         }
 
         if (!empty($data['nodes']) && is_array($data['nodes'])) {

--- a/src/Models/Map.php
+++ b/src/Models/Map.php
@@ -35,6 +35,16 @@ class Map extends Model
         return data_get($this->options, 'background', '#ffffff');
     }
 
+    public function getTagsAttribute()
+    {
+        $tags = data_get($this->options, 'tags', []);
+        if (!is_array($tags)) {
+            return [];
+        }
+        $normalized = array_map(fn($t) => is_string($t) ? strtolower(trim($t)) : '', $tags);
+        return array_values(array_unique(array_filter($normalized, fn($t) => $t !== '')));
+    }
+
     public function toJsonModel()
     {
         // Prime batch caches so accessor-backed fields (device_name, status,

--- a/src/Services/MapService.php
+++ b/src/Services/MapService.php
@@ -29,15 +29,13 @@ class MapService
 
     public function updateMap(Map $map, array $data): Map
     {
-        $options = array_merge($map->options ?? [], array_filter([
+        $incomingOptions = array_filter([
             'width' => $data['width'] ?? null,
             'height' => $data['height'] ?? null,
             'background' => $data['background'] ?? null,
-        ], fn($value) => $value !== null));
+        ], fn($value) => $value !== null);
 
-        // Ensure width/height always have defaults
-        $options['width'] = $options['width'] ?? 800;
-        $options['height'] = $options['height'] ?? 600;
+        $options = $this->mergeMapOptions($map->options ?? [], $incomingOptions);
 
         $update = ['options' => $options];
         if (array_key_exists('title', $data) && Schema::hasColumn('wmng_maps', 'title')) {

--- a/tests/MapModelTest.php
+++ b/tests/MapModelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class MapModelTest extends TestCase
+{
+    public function test_map_has_tags_accessor(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Models/Map.php');
+        $this->assertStringContainsString('public function getTagsAttribute()', $content);
+        $this->assertStringContainsString("data_get(\$this->options, 'tags', []);", $content);
+    }
+
+    public function test_tags_accessor_normalizes_invalid_values(): void
+    {
+        $reflection = new \ReflectionClass('LibreNMS\\Plugins\\WeathermapNG\\Models\\Map');
+        $method = $reflection->getMethod('getTagsAttribute');
+        $map = $reflection->newInstanceWithoutConstructor();
+
+        // Set options via reflection
+        $prop = $reflection->getProperty('attributes');
+        $prop->setAccessible(true);
+        $prop->setValue($map, ['options' => json_encode(['tags' => [' core ', '', 'WAN', null, 123]])]);
+
+        $tags = $method->invoke($map);
+        $this->assertSame(['core', 'wan'], $tags);
+    }
+
+    public function test_tags_accessor_deduplicates(): void
+    {
+        $reflection = new \ReflectionClass('LibreNMS\\Plugins\\WeathermapNG\\Models\\Map');
+        $method = $reflection->getMethod('getTagsAttribute');
+        $map = $reflection->newInstanceWithoutConstructor();
+
+        $prop = $reflection->getProperty('attributes');
+        $prop->setAccessible(true);
+        $prop->setValue($map, ['options' => json_encode(['tags' => ['core', 'Core', 'CORE', 'wan']])]);
+
+        $tags = $method->invoke($map);
+        $this->assertSame(['core', 'wan'], $tags);
+    }
+}

--- a/tests/SanitizationTest.php
+++ b/tests/SanitizationTest.php
@@ -191,4 +191,38 @@ class SanitizationTest extends TestCase
         $data = $this->sanitizeLinkStyle(['nodes' => [['label' => 'r1']]]);
         $this->assertArrayNotHasKey('links', $data);
     }
+
+    // --- SaveMapRequest tag sanitization ---
+
+    private function sanitizeTags(array $data): array
+    {
+        if (!empty($data['options']['tags']) && is_array($data['options']['tags'])) {
+            $tags = array_map(fn($t) => is_string($t) ? strtolower(strip_tags(trim($t))) : '', $data['options']['tags']);
+            $tags = array_values(array_unique(array_filter($tags, fn($t) => $t !== '')));
+            $data['options']['tags'] = $tags;
+        }
+        return $data;
+    }
+
+    public function test_tags_stripped_trimmed_lowercased_and_deduplicated(): void
+    {
+        $data = $this->sanitizeTags([
+            'options' => ['tags' => [' core ', 'WAN', '', '<b>alert</b>', '  ', 'wan']],
+        ]);
+        $this->assertSame(['core', 'wan', 'alert'], $data['options']['tags']);
+    }
+
+    public function test_tags_rejects_non_strings_but_preserves_valid(): void
+    {
+        $data = $this->sanitizeTags([
+            'options' => ['tags' => ['valid', 123, null, 'also-valid']],
+        ]);
+        $this->assertSame(['valid', 'also-valid'], $data['options']['tags']);
+    }
+
+    public function test_missing_tags_left_unchanged(): void
+    {
+        $data = $this->sanitizeTags(['options' => ['width' => 800]]);
+        $this->assertArrayNotHasKey('tags', $data['options']);
+    }
 }

--- a/tests/TagsFeatureTest.php
+++ b/tests/TagsFeatureTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class TagsFeatureTest extends TestCase
+{
+    private string $mapModel;
+    private string $saveRequest;
+    private string $mapService;
+    private string $indexView;
+    private string $editorView;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mapModel = file_get_contents(__DIR__ . '/../src/Models/Map.php');
+        $this->saveRequest = file_get_contents(__DIR__ . '/../src/Http/Requests/SaveMapRequest.php');
+        $this->mapService = file_get_contents(__DIR__ . '/../src/Services/MapService.php');
+        $this->indexView = file_get_contents(__DIR__ . '/../resources/views/index.blade.php');
+        $this->editorView = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+    }
+
+    public function test_map_model_has_tags_accessor(): void
+    {
+        $this->assertStringContainsString('public function getTagsAttribute()', $this->mapModel);
+        $this->assertStringContainsString("data_get(\$this->options, 'tags', []);", $this->mapModel);
+        $this->assertStringContainsString('array_unique', $this->mapModel);
+        $this->assertStringContainsString('strtolower', $this->mapModel);
+    }
+
+    public function test_save_request_validates_tags(): void
+    {
+        $this->assertStringContainsString("'options.tags' => 'nullable|array|max:50'", $this->saveRequest);
+        $this->assertStringContainsString("'options.tags.*' => 'nullable|string|max:50|regex:/^[a-z0-9_-]+$/i'", $this->saveRequest);
+    }
+
+    public function test_save_request_sanitizes_tags(): void
+    {
+        $this->assertStringContainsString("if (!empty(\$data['options']['tags']) && is_array(\$data['options']['tags']))", $this->saveRequest);
+        $this->assertStringContainsString('array_unique', $this->saveRequest);
+        $this->assertStringContainsString('strtolower', $this->saveRequest);
+    }
+
+    public function test_map_service_uses_merge_map_options(): void
+    {
+        $this->assertStringContainsString('$this->mergeMapOptions($map->options ?? [], $incomingOptions);', $this->mapService);
+    }
+
+    public function test_index_view_has_tag_filter_and_chips(): void
+    {
+        $this->assertStringContainsString("id=\"map-tag-filter\"", $this->indexView);
+        $this->assertStringContainsString("data-tags=\"{{ json_encode(\$map->tags) }}\"", $this->indexView);
+        $this->assertStringContainsString("class=\"map-tags\"", $this->indexView);
+        $this->assertStringContainsString("class=\"map-tag\"", $this->indexView);
+        $this->assertStringContainsString("getCardTags(card)", $this->indexView);
+    }
+
+    public function test_index_view_has_onboarding_links(): void
+    {
+        $this->assertStringContainsString('wmng-onboarding-actions', $this->indexView);
+        $this->assertStringContainsString("href=\"{{ url('plugin/WeathermapNG/templates') }}\"", $this->indexView);
+        $this->assertStringContainsString("href=\"{{ url('plugin/WeathermapNG/diagnostics') }}\"", $this->indexView);
+        $this->assertStringContainsString("data-target=\"#importMapModal\"", $this->indexView);
+    }
+
+    public function test_editor_view_has_tags_input(): void
+    {
+        $this->assertStringContainsString("id=\"map-tags\"", $this->editorView);
+        $this->assertStringContainsString('parseMapTags', $this->editorView);
+        $this->assertStringContainsString('tags: parseMapTags', $this->editorView);
+    }
+}


### PR DESCRIPTION
Adds map organization via tags and improves the empty-state onboarding experience.

**Tags**
- Tags are stored in `wmng_maps.options.tags` as lowercase strings (no migration needed).
- Editor Map Settings panel has a comma-separated tags input with live preview chips.
- Index view shows tag chips on map cards and a tag filter dropdown.
- `SaveMapRequest` validates tags as letters/numbers/hyphens/underscores, max 50 tags × 50 chars; sanitize normalizes, trims, lowercases, and deduplicates.
- `MapService::updateMap()` now uses `mergeMapOptions()` so existing options like tags are preserved when updating width/height/background.

**Onboarding**
- Empty-state panel now offers Templates, Custom Create, Import, Diagnostics, and Docs actions.

**Verification**
- PHPUnit: 241 tests, 805 assertions, OK (1 skipped).
- API round-trip smoke: POST `/api/maps/1/save` with tags succeeded; reloaded index showed new tags in the filter dropdown, and duplicate `wan` appeared only once.

**Files changed**
- `src/Models/Map.php`
- `src/Http/Requests/SaveMapRequest.php`
- `src/Services/MapService.php`
- `resources/views/editor.blade.php`
- `resources/views/index.blade.php`
- `tests/MapModelTest.php`
- `tests/SanitizationTest.php`
- `tests/TagsFeatureTest.php`
- `CHANGELOG.md`
- `README.md`