### PR TITLE
fix(editor): issue #11 follow-ups + lingering persistence/live-preview bugs

### DIFF
--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -1757,7 +1757,14 @@ function populateNodeProperties(node) {
     if (card) card.style.display = 'block';
 
     // Populate label
-    if (label) label.value = node.label || '';
+    if (label) {
+        label.value = node.label || '';
+        label.oninput = function() {
+            node.label = this.value;
+            renderEditor();
+            renderNodesList();
+        };
+    }
 
     // Populate device dropdown from cache
     if (devSel) {
@@ -1773,6 +1780,9 @@ function populateNodeProperties(node) {
         // Update interface when device changes
         devSel.onchange = function() {
             node.deviceId = this.value ? parseInt(this.value, 10) : null;
+            node.interfaceId = null;
+            renderEditor();
+            renderNodesList();
             loadInterfacesForNode(node);
         };
     }
@@ -1786,6 +1796,11 @@ function loadInterfacesForNode(node) {
     if (!intSel) return;
 
     intSel.innerHTML = '<option value="">No interface</option>';
+    intSel.onchange = function() {
+        node.interfaceId = this.value ? parseInt(this.value, 10) : null;
+        renderEditor();
+        renderNodesList();
+    };
     if (!node.deviceId) return;
 
     fetch('{{ url('plugin/WeathermapNG/api/device') }}/' + node.deviceId + '/ports')

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -430,8 +430,20 @@
                     <select id="link-dst-port" class="form-control"></select>
                 </div>
                 <div class="mb-3">
-                    <label class="form-label">Bandwidth (bps)</label>
-                    <input type="number" id="link-bandwidth" class="form-control" min="0" placeholder="e.g. 1000000000 for 1Gbps">
+                    <label class="form-label">Bandwidth</label>
+                    <div class="input-group">
+                        <input type="number" id="link-bandwidth-value" class="form-control" min="0" step="any" placeholder="e.g. 1">
+                        <select id="link-bandwidth-unit" class="form-control" style="max-width: 120px;">
+                            <option value="bps">bps</option>
+                            <option value="Kbps">Kbps</option>
+                            <option value="Mbps">Mbps</option>
+                            <option value="Gbps">Gbps</option>
+                            <option value="KBps">KBps</option>
+                            <option value="MBps">MBps</option>
+                            <option value="GBps">GBps</option>
+                        </select>
+                    </div>
+                    <small class="form-text text-muted">Stored internally as bits per second.</small>
                 </div>
                 <div class="mb-3">
                     <label class="form-label">Via Style</label>
@@ -633,6 +645,44 @@
 
             // Escape user-controlled strings before interpolating into innerHTML (XSS hardening).
             function escapeHtml(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
+
+            const BANDWIDTH_UNITS = {
+                bps: 1,
+                Kbps: 1000,
+                Mbps: 1000 * 1000,
+                Gbps: 1000 * 1000 * 1000,
+                KBps: 8 * 1000,
+                MBps: 8 * 1000 * 1000,
+                GBps: 8 * 1000 * 1000 * 1000,
+            };
+
+            function bandwidthInputsToBps(value, unit) {
+                const num = parseFloat(value);
+                if (isNaN(num) || num < 0) return null;
+                const factor = BANDWIDTH_UNITS[unit] || 1;
+                return Math.round(num * factor);
+            }
+
+            function setBandwidthInputsFromBps(bps, valueInput, unitSelect) {
+                if (!valueInput || !unitSelect) return;
+                if (!bps || isNaN(bps) || bps <= 0) {
+                    valueInput.value = '';
+                    unitSelect.value = 'bps';
+                    return;
+                }
+                const unitsBySize = ['GBps', 'Gbps', 'MBps', 'Mbps', 'KBps', 'Kbps', 'bps'];
+                for (const unit of unitsBySize) {
+                    const factor = BANDWIDTH_UNITS[unit];
+                    const val = bps / factor;
+                    if (Math.abs(val - Math.round(val)) < 0.0001 && val >= 1) {
+                        valueInput.value = Number.isInteger(val) ? val : parseFloat(val.toFixed(3));
+                        unitSelect.value = unit;
+                        return;
+                    }
+                }
+                valueInput.value = bps;
+                unitSelect.value = 'bps';
+            }
 
             function parseMapTags(raw) {
                 if (typeof raw !== 'string' || !raw.trim()) return [];
@@ -1954,14 +2004,15 @@ function openLinkModal(linkIndex) {
     const dstNode = findNodeById(link.dstId);
     const srcPortSelect = document.getElementById('link-src-port');
     const dstPortSelect = document.getElementById('link-dst-port');
-    const bandwidthInput = document.getElementById('link-bandwidth');
+    const bandwidthValue = document.getElementById('link-bandwidth-value');
+    const bandwidthUnit = document.getElementById('link-bandwidth-unit');
     const deleteBtn = document.getElementById('delete-link-btn');
     const viaStyleSelect = document.getElementById('link-via-style');
 
     // Reset dropdowns
     srcPortSelect.innerHTML = '<option value="">Select port...</option>';
     dstPortSelect.innerHTML = '<option value="">Select port...</option>';
-    bandwidthInput.value = link.bw || '';
+    setBandwidthInputsFromBps(link.bw, bandwidthValue, bandwidthUnit);
     viaStyleSelect.value = (link.style && link.style.via_style) || 'straight';
     deleteBtn.style.display = 'inline-block';
 
@@ -2011,13 +2062,17 @@ function saveLink() {
 
     link.portA = document.getElementById('link-src-port').value || null;
     link.portB = document.getElementById('link-dst-port').value || null;
-    link.bw = parseInt(document.getElementById('link-bandwidth').value, 10) || null;
+    link.bw = bandwidthInputsToBps(
+        document.getElementById('link-bandwidth-value').value,
+        document.getElementById('link-bandwidth-unit').value
+    );
     const viaStyle = document.getElementById('link-via-style').value || 'straight';
     if (!link.style) link.style = {};
     link.style.via_style = viaStyle;
 
     $('#linkModal').modal('hide');
     currentLinkIndex = null;
+    renderEditor();
     renderLinksList();
     WMNGToast.success('Link updated!', { duration: 2000 });
 }

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -1179,6 +1179,68 @@
             // Initialize minimap on page load
             document.addEventListener('DOMContentLoaded', initMinimap);
 
+            // ========== Default Styles Live Preview ==========
+            function initDefaultStyleListeners() {
+                const nodeColor = document.getElementById('default-node-color');
+                const nodeLabelColor = document.getElementById('default-node-label-color');
+                const linkColor = document.getElementById('default-link-color');
+                const linkWidth = document.getElementById('default-link-width');
+                const linkViaStyle = document.getElementById('default-link-via-style');
+                const mapTitle = document.getElementById('map-title');
+                const mapTags = document.getElementById('map-tags');
+
+                const hexRegex = /^#[0-9a-fA-F]{6}$/;
+
+                if (nodeColor) {
+                    nodeColor.addEventListener('input', function() {
+                        if (hexRegex.test(this.value)) { renderEditor(); renderNodesList(); }
+                        markUnsaved();
+                    });
+                }
+                if (nodeLabelColor) {
+                    nodeLabelColor.addEventListener('input', function() {
+                        if (hexRegex.test(this.value)) { renderEditor(); renderNodesList(); }
+                        markUnsaved();
+                    });
+                }
+                if (linkColor) {
+                    linkColor.addEventListener('input', function() {
+                        if (hexRegex.test(this.value)) { renderEditor(); renderLinksList(); }
+                        markUnsaved();
+                    });
+                }
+                if (linkWidth) {
+                    linkWidth.addEventListener('input', function() {
+                        const w = parseFloat(this.value);
+                        if (!isNaN(w) && w >= 0.5 && w <= 20) { renderEditor(); renderLinksList(); }
+                        markUnsaved();
+                    });
+                }
+                if (linkViaStyle) {
+                    linkViaStyle.addEventListener('change', function() {
+                        renderEditor();
+                        renderLinksList();
+                        markUnsaved();
+                    });
+                }
+                if (mapTitle) {
+                    mapTitle.addEventListener('input', function() {
+                        markUnsaved();
+                    });
+                }
+                const mapName = document.getElementById('map-name');
+                if (mapName) {
+                    mapName.addEventListener('input', function() {
+                        markUnsaved();
+                    });
+                }
+                if (mapTags) {
+                    mapTags.addEventListener('input', function() {
+                        markUnsaved();
+                    });
+                }
+            }
+
             // ========== Canvas Resize Validation ==========
             function initCanvasResizeValidation() {
                 const widthInput = document.getElementById('map-width');
@@ -1191,6 +1253,9 @@
                             validateAndApplyCanvasResize(newWidth, canvas.height);
                         }
                     });
+                    widthInput.addEventListener('input', function() {
+                        markUnsaved();
+                    });
                 }
 
                 if (heightInput) {
@@ -1199,6 +1264,9 @@
                         if (newHeight && newHeight >= 100) {
                             validateAndApplyCanvasResize(canvas.width, newHeight);
                         }
+                    });
+                    heightInput.addEventListener('input', function() {
+                        markUnsaved();
                     });
                 }
             }
@@ -1243,6 +1311,7 @@
             }
 
             document.addEventListener('DOMContentLoaded', initCanvasResizeValidation);
+            document.addEventListener('DOMContentLoaded', initDefaultStyleListeners);
 
             // ========== Keyboard Shortcuts ==========
             function initKeyboardShortcuts() {
@@ -1694,6 +1763,7 @@
                     default_link_style: defaultLinkStyle,
                 };
                 const payload = {
+                    name: mapName,
                     title: mapTitle,
                     options,
                     nodes: nodes.map(n => ({
@@ -1813,6 +1883,7 @@ function populateNodeProperties(node) {
             node.label = this.value;
             renderEditor();
             renderNodesList();
+            markUnsaved();
         };
     }
 
@@ -1833,6 +1904,7 @@ function populateNodeProperties(node) {
             node.interfaceId = null;
             renderEditor();
             renderNodesList();
+            markUnsaved();
             loadInterfacesForNode(node);
         };
     }
@@ -1850,6 +1922,7 @@ function loadInterfacesForNode(node) {
         node.interfaceId = this.value ? parseInt(this.value, 10) : null;
         renderEditor();
         renderNodesList();
+        markUnsaved();
     };
     if (!node.deviceId) return;
 
@@ -2072,6 +2145,7 @@ function saveLink() {
 
     $('#linkModal').modal('hide');
     currentLinkIndex = null;
+    markUnsaved();
     renderEditor();
     renderLinksList();
     WMNGToast.success('Link updated!', { duration: 2000 });

--- a/src/Http/Requests/SaveMapRequest.php
+++ b/src/Http/Requests/SaveMapRequest.php
@@ -17,6 +17,7 @@ class SaveMapRequest extends FormRequest
     {
         return [
             'title' => 'nullable|string|max:255',
+            'name' => 'nullable|string|max:255|alpha_dash|regex:/^[a-z0-9_-]+$/i',
             'options' => 'nullable|array',
             'options.width' => 'nullable|integer|min:100|max:4096',
             'options.height' => 'nullable|integer|min:100|max:4096',
@@ -133,8 +134,10 @@ class SaveMapRequest extends FormRequest
 
     public function sanitize(array $data): array
     {
-        if (isset($data['title']) && is_string($data['title'])) {
-            $data['title'] = strip_tags($data['title']);
+        foreach (['title', 'name'] as $key) {
+            if (isset($data[$key]) && is_string($data[$key])) {
+                $data[$key] = strip_tags(trim($data[$key]));
+            }
         }
 
         if (!empty($data['options']['tags']) && is_array($data['options']['tags'])) {
@@ -171,7 +174,7 @@ class SaveMapRequest extends FormRequest
                     continue;
                 }
                 if (isset($node['label']) && is_string($node['label'])) {
-                    $data['nodes'][$i]['label'] = strip_tags($node['label']);
+                    $data['nodes'][$i]['label'] = strip_tags(trim($node['label']));
                 }
             }
         }

--- a/src/Models/Link.php
+++ b/src/Models/Link.php
@@ -17,7 +17,14 @@ class Link extends Model
         'bandwidth_bps',
         'style'
     ];
-    protected $casts = ['style' => 'array'];
+    protected $casts = [
+        'style' => 'array',
+        'src_node_id' => 'integer',
+        'dst_node_id' => 'integer',
+        'port_id_a' => 'integer',
+        'port_id_b' => 'integer',
+        'bandwidth_bps' => 'integer',
+    ];
 
     /** @var array<int,?string> Batch-prefetch cache for port ifName lookups. */
     private static array $portNameCache = [];

--- a/src/Models/Node.php
+++ b/src/Models/Node.php
@@ -9,7 +9,12 @@ class Node extends Model
 {
     protected $table = 'wmng_nodes';
     protected $fillable = ['map_id', 'label', 'x', 'y', 'device_id', 'meta'];
-    protected $casts = ['meta' => 'array'];
+    protected $casts = [
+        'meta' => 'array',
+        'device_id' => 'integer',
+        'x' => 'float',
+        'y' => 'float',
+    ];
 
     /** @var array<int, array<string,mixed>|null> Batch-prefetch cache for device lookups. */
     private static array $deviceCache = [];

--- a/src/Services/MapService.php
+++ b/src/Services/MapService.php
@@ -107,6 +107,9 @@ class MapService
         if (array_key_exists('title', $data) && Schema::hasColumn('wmng_maps', 'title')) {
             $updates['title'] = $data['title'];
         }
+        if (array_key_exists('name', $data) && $data['name'] !== null && $data['name'] !== '' && Schema::hasColumn('wmng_maps', 'name')) {
+            $updates['name'] = $data['name'];
+        }
 
         if (!empty($updates)) {
             $map->fill($updates)->save();
@@ -142,9 +145,9 @@ class MapService
             $node = Node::create([
                 'map_id' => $map->id,
                 'label' => $nodeData['label'] ?? 'Node',
-                'x' => $nodeData['x'] ?? 0,
-                'y' => $nodeData['y'] ?? 0,
-                'device_id' => $nodeData['device_id'] ?? null,
+                'x' => isset($nodeData['x']) && is_numeric($nodeData['x']) ? (float) $nodeData['x'] : 0,
+                'y' => isset($nodeData['y']) && is_numeric($nodeData['y']) ? (float) $nodeData['y'] : 0,
+                'device_id' => isset($nodeData['device_id']) && is_numeric($nodeData['device_id']) ? (int) $nodeData['device_id'] : null,
                 'meta' => $nodeData['meta'] ?? [],
             ]);
 
@@ -168,9 +171,9 @@ class MapService
                 'map_id' => $map->id,
                 'src_node_id' => $sourceId,
                 'dst_node_id' => $targetId,
-                'port_id_a' => $linkData['port_id_a'] ?? $linkData['port_a'] ?? null,
-                'port_id_b' => $linkData['port_id_b'] ?? $linkData['port_b'] ?? null,
-                'bandwidth_bps' => $linkData['bandwidth_bps'] ?? $linkData['bandwidth'] ?? null,
+                'port_id_a' => isset($linkData['port_id_a']) && is_numeric($linkData['port_id_a']) ? (int) $linkData['port_id_a'] : (isset($linkData['port_a']) && is_numeric($linkData['port_a']) ? (int) $linkData['port_a'] : null),
+                'port_id_b' => isset($linkData['port_id_b']) && is_numeric($linkData['port_id_b']) ? (int) $linkData['port_id_b'] : (isset($linkData['port_b']) && is_numeric($linkData['port_b']) ? (int) $linkData['port_b'] : null),
+                'bandwidth_bps' => isset($linkData['bandwidth_bps']) && is_numeric($linkData['bandwidth_bps']) ? (int) $linkData['bandwidth_bps'] : (isset($linkData['bandwidth']) && is_numeric($linkData['bandwidth']) ? (int) $linkData['bandwidth'] : null),
                 'style' => $linkData['style'] ?? [],
             ]);
         }

--- a/tests/EditorPropertiesTest.php
+++ b/tests/EditorPropertiesTest.php
@@ -42,4 +42,41 @@ class EditorPropertiesTest extends TestCase
         $this->assertStringContainsString('renderEditor()', $saveBlock);
         $this->assertStringContainsString('renderLinksList()', $saveBlock);
     }
+
+    public function test_node_property_inputs_mark_unsaved(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $labelBlock = substr($content, strpos($content, 'label.oninput = function'), 250);
+        $this->assertStringContainsString('markUnsaved()', $labelBlock);
+
+        $devBlock = substr($content, strpos($content, 'devSel.onchange = function'), 250);
+        $this->assertStringContainsString('markUnsaved()', $devBlock);
+    }
+
+    public function test_save_existing_map_payload_includes_name(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $existingBlockStart = strpos($content, "WMNGLoading.show('Saving map...')");
+        $this->assertNotFalse($existingBlockStart);
+        $saveBlock = substr($content, $existingBlockStart, 900);
+        $this->assertStringContainsString('name: mapName', $saveBlock);
+    }
+
+    public function test_default_style_panel_wires_live_preview(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $this->assertStringContainsString('function initDefaultStyleListeners()', $content);
+        $this->assertStringContainsString("nodeColor.addEventListener('input'", $content);
+        $this->assertStringContainsString("linkWidth.addEventListener('input'", $content);
+        $this->assertStringContainsString("mapName.addEventListener('input'", $content);
+    }
+
+    public function test_map_dimensions_mark_unsaved_on_input(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $resizeBlock = substr($content, strpos($content, 'function initCanvasResizeValidation()'), 1500);
+        $this->assertStringContainsString("widthInput.addEventListener('input'", $resizeBlock);
+        $this->assertStringContainsString("heightInput.addEventListener('input'", $resizeBlock);
+        $this->assertStringContainsString('markUnsaved()', $resizeBlock);
+    }
 }

--- a/tests/EditorPropertiesTest.php
+++ b/tests/EditorPropertiesTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class EditorPropertiesTest extends TestCase
+{
+    public function test_node_label_input_updates_canvas_and_nodes_list(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $this->assertStringContainsString('id="node-prop-label"', $content);
+        $this->assertStringContainsString('label.oninput = function', $content);
+        $this->assertStringContainsString('node.label = this.value', $content);
+        // Should trigger immediate re-renders after label/device/interface changes.
+        $inputsBlock = substr($content, strpos($content, 'label.oninput = function'), 300);
+        $this->assertStringContainsString('renderEditor()', $inputsBlock);
+        $this->assertStringContainsString('renderNodesList()', $inputsBlock);
+    }
+
+    public function test_link_bandwidth_has_value_and_unit_inputs(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $this->assertStringContainsString('id="link-bandwidth-value"', $content);
+        $this->assertStringContainsString('id="link-bandwidth-unit"', $content);
+        $this->assertStringContainsString('<option value="Mbps">Mbps</option>', $content);
+        $this->assertStringContainsString('<option value="MBps">MBps</option>', $content);
+    }
+
+    public function test_link_bandwidth_conversion_helpers_exist(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $this->assertStringContainsString('function bandwidthInputsToBps', $content);
+        $this->assertStringContainsString('function setBandwidthInputsFromBps', $content);
+        $this->assertStringContainsString("MBps: 8 * 1000 * 1000", $content);
+    }
+
+    public function test_link_save_renders_canvas_and_links_list(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../resources/views/editor.blade.php');
+        $saveBlock = substr($content, strpos($content, 'function saveLink()'), 1200);
+        $this->assertStringContainsString('renderEditor()', $saveBlock);
+        $this->assertStringContainsString('renderLinksList()', $saveBlock);
+    }
+}

--- a/tests/MapRequestRulesTest.php
+++ b/tests/MapRequestRulesTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class MapRequestRulesTest extends TestCase
+{
+    public function test_save_map_request_allows_name_field(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Http/Requests/SaveMapRequest.php');
+        $this->assertStringContainsString("'name' => 'nullable|string|max:255|alpha_dash|regex:/^[a-z0-9_-]+$/i'", $content);
+    }
+
+    public function test_save_map_request_sanitizes_name(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Http/Requests/SaveMapRequest.php');
+        $this->assertStringContainsString("foreach (['title', 'name'] as \$key)", $content);
+        $this->assertStringContainsString('strip_tags(trim($data[$key]))', $content);
+    }
+
+    public function test_map_service_updates_name_when_present(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Services/MapService.php');
+        $this->assertStringContainsString("array_key_exists('name', \$data) && \$data['name'] !== null && \$data['name'] !== ''", $content);
+    }
+
+    public function test_save_map_request_allows_partial_default_styles(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Http/Requests/SaveMapRequest.php');
+        // Laravel array:foo restricts allowed keys and does NOT require them all.
+        $this->assertStringContainsString("'options.default_node_style' => 'nullable|array:color,label_color'", $content);
+        $this->assertStringContainsString("'options.default_link_style' => 'nullable|array:color,width,via_style'", $content);
+    }
+}

--- a/tests/NodeLinkModelTest.php
+++ b/tests/NodeLinkModelTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class NodeLinkModelTest extends TestCase
+{
+    public function test_node_casts_numeric_columns(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Models/Node.php');
+        $this->assertStringContainsString("'device_id' => 'integer'", $content);
+        $this->assertStringContainsString("'x' => 'float'", $content);
+        $this->assertStringContainsString("'y' => 'float'", $content);
+    }
+
+    public function test_link_casts_numeric_columns(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Models/Link.php');
+        $this->assertStringContainsString("'src_node_id' => 'integer'", $content);
+        $this->assertStringContainsString("'dst_node_id' => 'integer'", $content);
+        $this->assertStringContainsString("'port_id_a' => 'integer'", $content);
+        $this->assertStringContainsString("'port_id_b' => 'integer'", $content);
+        $this->assertStringContainsString("'bandwidth_bps' => 'integer'", $content);
+    }
+}


### PR DESCRIPTION
Fixes the remaining UX issues reported in #11 after the destructive-save race was resolved, plus several related persistence/live-preview bugs found in a follow-up audit.

### User-reported bugs
1. **Canvas label doesn't update until reopen**: editing a node's label now live-updates the canvas and nodes list via `oninput`.
2. **Link bandwidth doesn't actually change**: the Configure Link dialog now has value + unit controls (`bps/Kbps/Mbps/Gbps/KBps/MBps/GBps`) and converts to `bandwidth_bps` before the save payload. `1000 Mbps` -> `1,000,000,000` bps; `1000 MBps` -> `8,000,000,000` bps.

### Additional bugs found during audit of editor persistence
3. **Map Name edits discarded on existing maps**: `#map-name` is now sent in the save payload and persisted by `MapService::updateMapProperties()` (only when non-empty, so the field cannot accidentally empty the DB).
4. **Unsaved badge ignored by property panels**: node label/device/interface, default style panel inputs, and map width/height/title/name now call `markUnsaved()`.
5. **Default style panel didn't live-preview**: added `initDefaultStyleListeners()` so default node/link styles redraw the canvas/list as you type (hex/valid values only).
6. **Numeric DB fields stored as strings**: `MapService::createNodes/createLinks` cast `x/y` to float, `device_id`/`port_id_a/b`/`bandwidth_bps` to int. `Node` and `Link` models also add integer/float `$casts`.
7. **Labels/titles retained leading/trailing whitespace**: `SaveMapRequest::sanitize()` now trims name, title, and node labels after `strip_tags()`.

### Tests
- Added `tests/EditorPropertiesTest.php` for label input, bandwidth units, link save render, map-name payload, default style wiring, and dimension unsaved indicators.
- Added `tests/MapRequestRulesTest.php` for name field rule and sanitization, and `tests/NodeLinkModelTest.php` for numeric casts.
- Full PHPUnit: 263 tests, 866 assertions, OK (1 skipped).
- Container smoke: login, editor 200, rename save returned 200, name persisted on reload.

### Not addressed here
- Embed tooltip color/unit formatting and flow-particle recalculation are known UI polish items but separate from the save/preview bugs reported in #11.
- Dead `wmng_maps.width/height/description` columns vs JSON `options` is a larger schema-alignment decision deferred.
