### PR TITLE
fix(editor/embed): post-#22 audit — XSS-safe JSON, legacy names, link style keys, node-id fallback

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,28 @@
+Fixes correctness and security regressions found in a follow-up audit after #22.
+
+## What #22 fixed
+- Node label live-preview, link bandwidth units, and map dimension inputs now wire `markUnsaved()`.
+- Existing-map saves include and persist `name`.
+- SaveMapRequest sanitizes `name`/`title` and trims node labels; MapService persists `name` when present.
+- Node/link numeric casts updated upstream.
+
+## Findings from this audit + fixes in this PR
+
+| Severity | Issue | Fix |
+|---|---|---|
+| High | `embed.blade.php` injected `json_encode()` raw into a `<script>` block; user-controlled map/node/link strings (e.g. a node label containing `<!--`) could break JS parsing or open XSS. | Replaced all `{!! json_encode(...) !!}` in the embed script block with `@json(...)`, which uses Laravel's HTML/hex escaping. |
+| Medium | `SaveMapRequest` `name` rule required ASCII-only slugs, so existing legacy maps with dots/Unicode names could no longer be saved. | Relaxed to `nullable|string|max:255`; create-time restrictions remain on `CreateMapRequest`. Trailing whitespace is still trimmed in `prepareForValidation()`. |
+| Medium | `SaveMapRequest` only allow-listed `via_style`/`via_points` inside `links.*.style`; existing rows that store `color`/`width` failed validation on load-then-save. | Allow-listed and validated `color`/`width`, with matching sanitization. Updated the error message. |
+| Medium | `MapService::resolveNodeId()` fell back to the raw numeric client ID when the new node map missed it, allowing cross-map/orphan links. | Removed the numeric fallback; unresolved IDs become `null`. |
+| Medium | Embed canvas always fell back to hard-coded `#ffffff`, ignoring configured map background color. | Uses `mapData.background` as fallback fill. |
+
+## Tests
+- `MapRequestRulesTest`: updated name-rule assertion; added assertions for link-style `color`/`width` rules and the resolved-node-id removal.
+- `SanitizationTest`: updated the link-style sanitizer mirror to strip unknown keys and sanitize `color`/`width`; added coverage for out-of-range width removal and HTML-stripped color.
+- `UIEmbedKioskTest`: updated to expect `@json(...)` directives.
+- Full PHPUnit suite: **263 tests, 876 assertions, 0 failures** (1 skipped).
+- Container smoke: login → editor load → map JSON fetch → embed render → save with legacy Unicode/dot name and `<!--` label node succeeds; dev fixture restored from the latest map version afterwards.
+
+## Not addressed here
+- 0-bandwidth semantics remain as-is pending product decision.
+- Low-priority embed/kiosk URL regex/routing cleanups and map-tags duplicate listeners were scoped out to keep this PR clean.

--- a/resources/views/embed.blade.php
+++ b/resources/views/embed.blade.php
@@ -315,11 +315,11 @@
         const baseUrl = '{{ url("/") }}';
         const deviceBaseUrl = '{{ url("device") }}';
         const WMNG_CONFIG = {
-            kioskEnabled: {!! json_encode($kiosk) !!},
-            cycleSeconds: {!! json_encode($cycleSeconds) !!},
-            linkTarget: {!! json_encode($target) !!},
-            mapList: {!! json_encode($mapList ?? []) !!},
-            thresholds: {!! json_encode(config('weathermapng.thresholds') ?? [50, 80, 95]) !!},
+            kioskEnabled: @json($kiosk),
+            cycleSeconds: @json($cycleSeconds),
+            linkTarget: @json($target),
+            mapList: @json($mapList ?? []),
+            thresholds: @json(config('weathermapng.thresholds') ?? [50, 80, 95]),
             colors: {
                 link_normal: '{{ config('weathermapng.colors.link_normal', '#28a745') }}',
                 link_warning: '{{ config('weathermapng.colors.link_warning', '#ffc107') }}',
@@ -328,12 +328,12 @@
                 node_down: '{{ config('weathermapng.colors.node_down', '#dc3545') }}',
                 node_unknown: '{{ config('weathermapng.colors.node_unknown', '#6c757d') }}'
             },
-            enable_sse: {!! json_encode(config('weathermapng.enable_sse') ?? true) !!},
-            client_refresh: {!! json_encode(config('weathermapng.client_refresh') ?? 60) !!},
-            scale: {!! json_encode(config('weathermapng.scale') ?? 'bits') !!},
+            enable_sse: @json(config('weathermapng.enable_sse') ?? true),
+            client_refresh: @json(config('weathermapng.client_refresh') ?? 60),
+            scale: @json(config('weathermapng.scale') ?? 'bits'),
             link_style: '{{ config('weathermapng.link_style', 'straight') }}',
-            show_bandwidth: {!! json_encode(config('weathermapng.show_bandwidth', true)) !!},
-            show_percentages: {!! json_encode(config('weathermapng.show_percentages', true)) !!}
+            show_bandwidth: @json(config('weathermapng.show_bandwidth', true)),
+            show_percentages: @json(config('weathermapng.show_percentages', true))
         };
         const urlParams = new URLSearchParams(window.location.search);
         const param = (k, d) => urlParams.has(k) ? urlParams.get(k) : d;
@@ -350,9 +350,9 @@
         let lastDataUpdate = null;
         let mapData = {};
         try {
-            mapData = {!! json_encode($mapData ?? []) !!};
+            mapData = @json($mapData ?? []);
             // Apply initial live data if provided
-            const initialLive = {!! json_encode($liveData ?? []) !!};
+            const initialLive = @json($liveData ?? []);
             if (initialLive && initialLive.links && Array.isArray(mapData.links)) {
                 mapData.links.forEach(l => {
                     const id = l.id ?? l.link_id ?? null;
@@ -445,7 +445,7 @@
             if (bgImg) {
                 ctx.drawImage(bgImg, 0, 0, canvas.width, canvas.height);
             } else {
-                ctx.fillStyle = '#ffffff';
+                ctx.fillStyle = mapData.background || '#ffffff';
                 ctx.fillRect(0, 0, canvas.width, canvas.height);
             }
 

--- a/src/Http/Requests/SaveMapRequest.php
+++ b/src/Http/Requests/SaveMapRequest.php
@@ -17,7 +17,7 @@ class SaveMapRequest extends FormRequest
     {
         return [
             'title' => 'nullable|string|max:255',
-            'name' => 'nullable|string|max:255|alpha_dash|regex:/^[a-z0-9_-]+$/i',
+            'name' => 'nullable|string|max:255',
             'options' => 'nullable|array',
             'options.width' => 'nullable|integer|min:100|max:4096',
             'options.height' => 'nullable|integer|min:100|max:4096',
@@ -54,8 +54,10 @@ class SaveMapRequest extends FormRequest
             'links.*.port_b' => 'nullable|integer',
             'links.*.bandwidth_bps' => 'nullable|numeric|min:0',
             'links.*.bandwidth' => 'nullable|numeric|min:0',
-            'links.*.style' => 'nullable|array:via_style,via_points',
+            'links.*.style' => 'nullable|array:via_style,via_points,color,width',
             'links.*.style.via_style' => 'nullable|string|in:straight,angled,curved',
+            'links.*.style.color' => 'nullable|string|max:20|regex:/^#[0-9a-fA-F]{6}$/',
+            'links.*.style.width' => 'nullable|numeric|min:0.5|max:20',
             'links.*.style.via_points' => 'nullable|array|max:200',
             'links.*.style.via_points.*' => 'array:x,y',
             'links.*.style.via_points.*.x' => 'required|numeric|min:0|max:10000',
@@ -83,8 +85,11 @@ class SaveMapRequest extends FormRequest
             'options.default_link_style.width.min' => 'Default link width must be at least 0.5',
             'options.default_link_style.width.max' => 'Default link width must not exceed 20',
             'options.default_link_style.via_style.in' => 'Default link style must be straight, angled, or curved',
+            'links.*.style.color.regex' => 'Link style color must be a valid hex color',
+            'links.*.style.width.min' => 'Link width must be at least 0.5',
+            'links.*.style.width.max' => 'Link width must not exceed 20',
             'options.tags.*.regex' => 'Tags may only contain letters, numbers, hyphens and underscores',
-            'links.*.style.array' => 'Link style may only contain via_style and via_points',
+            'links.*.style.array' => 'Link style may only contain via_style, via_points, color, or width',
             'links.*.style.via_style.in' => 'Via style must be straight, angled, or curved',
             'links.*.style.via_points.*.x.numeric' => 'Via point x must be numeric',
             'links.*.style.via_points.*.y.numeric' => 'Via point y must be numeric',
@@ -186,8 +191,22 @@ class SaveMapRequest extends FormRequest
                 }
                 $style = $link['style'];
 
-                // Validation allowlists keys; here we cast numeric strings
+                // Validation allowlists keys; here we sanitize and cast numeric strings
                 // so the persisted JSON holds numbers, not stringified coords.
+                $allowedLinkStyleKeys = ['via_style', 'via_points', 'color', 'width'];
+                $style = array_intersect_key($style, array_flip($allowedLinkStyleKeys));
+                if (isset($style['color']) && is_string($style['color'])) {
+                    $style['color'] = strip_tags(trim($style['color']));
+                }
+                if (isset($style['width']) && is_numeric($style['width'])) {
+                    $w = (float) $style['width'];
+                    if ($w >= 0.5 && $w <= 20) {
+                        $style['width'] = $w;
+                    } else {
+                        unset($style['width']);
+                    }
+                }
+                $data['links'][$i]['style'] = $style;
                 if (!empty($style['via_points']) && is_array($style['via_points'])) {
                     foreach ($style['via_points'] as $j => $vp) {
                         if (!is_array($vp)) {
@@ -209,8 +228,10 @@ class SaveMapRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
-        if ($this->has('title') && is_string($this->input('title'))) {
-            $this->merge(['title' => trim($this->input('title'))]);
+        foreach (['title', 'name'] as $key) {
+            if ($this->has($key) && is_string($this->input($key))) {
+                $this->merge([$key => trim($this->input($key))]);
+            }
         }
     }
 }

--- a/src/Services/MapService.php
+++ b/src/Services/MapService.php
@@ -185,7 +185,7 @@ class MapService
             return null;
         }
 
-        return $nodeIdMap[$clientId] ?? (is_numeric($clientId) ? (int)$clientId : null);
+        return $nodeIdMap[$clientId] ?? null;
     }
 
     public function importMap(Request $request, array $validated): Map

--- a/tests/MapRequestRulesTest.php
+++ b/tests/MapRequestRulesTest.php
@@ -9,7 +9,7 @@ class MapRequestRulesTest extends TestCase
     public function test_save_map_request_allows_name_field(): void
     {
         $content = file_get_contents(__DIR__ . '/../src/Http/Requests/SaveMapRequest.php');
-        $this->assertStringContainsString("'name' => 'nullable|string|max:255|alpha_dash|regex:/^[a-z0-9_-]+$/i'", $content);
+        $this->assertStringContainsString("'name' => 'nullable|string|max:255'", $content);
     }
 
     public function test_save_map_request_sanitizes_name(): void
@@ -31,5 +31,20 @@ class MapRequestRulesTest extends TestCase
         // Laravel array:foo restricts allowed keys and does NOT require them all.
         $this->assertStringContainsString("'options.default_node_style' => 'nullable|array:color,label_color'", $content);
         $this->assertStringContainsString("'options.default_link_style' => 'nullable|array:color,width,via_style'", $content);
+    }
+
+    public function test_save_map_request_allows_link_style_color_and_width(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Http/Requests/SaveMapRequest.php');
+        $this->assertStringContainsString("'links.*.style' => 'nullable|array:via_style,via_points,color,width'", $content);
+        $this->assertStringContainsString("'links.*.style.color' => 'nullable|string|max:20|regex:/^#[0-9a-fA-F]{6}$/'", $content);
+        $this->assertStringContainsString("'links.*.style.width' => 'nullable|numeric|min:0.5|max:20'", $content);
+    }
+
+    public function test_map_service_has_no_numeric_fallback_for_node_ids(): void
+    {
+        $content = file_get_contents(__DIR__ . '/../src/Services/MapService.php');
+        $this->assertStringNotContainsString('is_numeric($clientId)', $content);
+        $this->assertStringContainsString('return $nodeIdMap[$clientId] ?? null;', $content);
     }
 }

--- a/tests/SanitizationTest.php
+++ b/tests/SanitizationTest.php
@@ -109,7 +109,8 @@ class SanitizationTest extends TestCase
 
     /**
      * Mirror of SaveMapRequest::sanitize() link style block — casts numeric
-     * strings in via_points to floats so persisted JSON holds numbers.
+     * strings in via_points to floats so persisted JSON holds numbers, and
+     * allowlists/strips link style color/width.
      */
     private function sanitizeLinkStyle(array $data): array
     {
@@ -119,6 +120,21 @@ class SanitizationTest extends TestCase
                     continue;
                 }
                 $style = $link['style'];
+
+                $allowedLinkStyleKeys = ['via_style', 'via_points', 'color', 'width'];
+                $style = array_intersect_key($style, array_flip($allowedLinkStyleKeys));
+                if (isset($style['color']) && is_string($style['color'])) {
+                    $style['color'] = strip_tags(trim($style['color']));
+                }
+                if (isset($style['width']) && is_numeric($style['width'])) {
+                    $w = (float) $style['width'];
+                    if ($w >= 0.5 && $w <= 20) {
+                        $style['width'] = $w;
+                    } else {
+                        unset($style['width']);
+                    }
+                }
+                $data['links'][$i]['style'] = $style;
                 if (!empty($style['via_points']) && is_array($style['via_points'])) {
                     foreach ($style['via_points'] as $j => $vp) {
                         if (!is_array($vp)) {
@@ -190,6 +206,30 @@ class SanitizationTest extends TestCase
     {
         $data = $this->sanitizeLinkStyle(['nodes' => [['label' => 'r1']]]);
         $this->assertArrayNotHasKey('links', $data);
+    }
+
+    public function test_link_style_unknown_keys_are_stripped(): void
+    {
+        $data = $this->sanitizeLinkStyle([
+            'links' => [['style' => ['via_style' => 'curved', 'bogus' => 'x', 'color' => '#ff0000', 'width' => 2.5]]],
+        ]);
+        $this->assertSame(['via_style' => 'curved', 'color' => '#ff0000', 'width' => 2.5], $data['links'][0]['style']);
+    }
+
+    public function test_link_style_color_html_is_stripped(): void
+    {
+        $data = $this->sanitizeLinkStyle([
+            'links' => [['style' => ['color' => '<script>alert(1)</script>#ff0000', 'width' => 2]]],
+        ]);
+        $this->assertSame('alert(1)#ff0000', $data['links'][0]['style']['color']);
+    }
+
+    public function test_link_style_width_out_of_range_is_removed(): void
+    {
+        $data = $this->sanitizeLinkStyle([
+            'links' => [['style' => ['width' => 99.0]]],
+        ]);
+        $this->assertArrayNotHasKey('width', $data['links'][0]['style']);
     }
 
     // --- SaveMapRequest tag sanitization ---

--- a/tests/UIEmbedKioskTest.php
+++ b/tests/UIEmbedKioskTest.php
@@ -16,10 +16,12 @@ class UIEmbedKioskTest extends TestCase
 
     public function test_embed_passes_kiosk_config_to_js(): void
     {
-        $this->assertStringContainsString("kioskEnabled: {!! json_encode(\$kiosk) !!}", $this->content);
-        $this->assertStringContainsString("cycleSeconds: {!! json_encode(\$cycleSeconds) !!}", $this->content);
-        $this->assertStringContainsString("linkTarget: {!! json_encode(\$target) !!}", $this->content);
-        $this->assertStringContainsString("mapList: {!! json_encode(\$mapList ?? []) !!}", $this->content);
+        $this->assertStringContainsString("kioskEnabled: @json(\$kiosk)", $this->content);
+        $this->assertStringContainsString("cycleSeconds: @json(\$cycleSeconds)", $this->content);
+        $this->assertStringContainsString("linkTarget: @json(\$target)", $this->content);
+        $this->assertStringContainsString("mapList: @json(\$mapList ?? [])", $this->content);
+        $this->assertStringContainsString("mapData = @json(\$mapData ?? [])", $this->content);
+        $this->assertStringContainsString("initialLive = @json(\$liveData ?? [])", $this->content);
     }
 
     public function test_embed_includes_kiosk_mode_styles(): void


### PR DESCRIPTION
Fixes correctness and security regressions found in a follow-up audit after #22.

## What #22 fixed
- Node label live-preview, link bandwidth units, and map dimension inputs now wire `markUnsaved()`.
- Existing-map saves include and persist `name`.
- SaveMapRequest sanitizes `name`/`title` and trims node labels; MapService persists `name` when present.
- Node/link numeric casts updated upstream.

## Findings from this audit + fixes in this PR

| Severity | Issue | Fix |
|---|---|---|
| High | `embed.blade.php` injected `json_encode()` raw into a `<script>` block; user-controlled map/node/link strings (e.g. a node label containing `<!--`) could break JS parsing or open XSS. | Replaced all `{!! json_encode(...) !!}` in the embed script block with `@json(...)`, which uses Laravel's HTML/hex escaping. |
| Medium | `SaveMapRequest` `name` rule required ASCII-only slugs, so existing legacy maps with dots/Unicode names could no longer be saved. | Relaxed to `nullable|string|max:255`; create-time restrictions remain on `CreateMapRequest`. Trailing whitespace is still trimmed in `prepareForValidation()`. |
| Medium | `SaveMapRequest` only allow-listed `via_style`/`via_points` inside `links.*.style`; existing rows that store `color`/`width` failed validation on load-then-save. | Allow-listed and validated `color`/`width`, with matching sanitization. Updated the error message. |
| Medium | `MapService::resolveNodeId()` fell back to the raw numeric client ID when the new node map missed it, allowing cross-map/orphan links. | Removed the numeric fallback; unresolved IDs become `null`. |
| Medium | Embed canvas always fell back to hard-coded `#ffffff`, ignoring configured map background color. | Uses `mapData.background` as fallback fill. |

## Tests
- `MapRequestRulesTest`: updated name-rule assertion; added assertions for link-style `color`/`width` rules and the resolved-node-id removal.
- `SanitizationTest`: updated the link-style sanitizer mirror to strip unknown keys and sanitize `color`/`width`; added coverage for out-of-range width removal and HTML-stripped color.
- `UIEmbedKioskTest`: updated to expect `@json(...)` directives.
- Full PHPUnit suite: **263 tests, 876 assertions, 0 failures** (1 skipped).
- Container smoke: login → editor load → map JSON fetch → embed render → save with legacy Unicode/dot name and `<!--` label node succeeds; dev fixture restored from the latest map version afterwards.

## Not addressed here
- 0-bandwidth semantics remain as-is pending product decision.
- Low-priority embed/kiosk URL regex/routing cleanups and map-tags duplicate listeners were scoped out to keep this PR clean.
