### PR TITLE
chore: dedup node-label sanitization tests into NodeLabelNormalizerTest

### DIFF
--- a/tests/SanitizationTest.php
+++ b/tests/SanitizationTest.php
@@ -50,45 +50,13 @@ class SanitizationTest extends TestCase
         $this->assertEquals('test-map', $data['name']);
         $this->assertArrayNotHasKey('title', $data);
     }
+    // --- SaveMapRequest node-label sanitization ---
+    // Node-label normalization is now unit-tested directly against the
+    // shared NodeLabelNormalizer in NodeLabelNormalizerTest (no mirrored
+    // helper needed — that was drift risk PR #27 acknowledged). The
+    // SanitizationTest keeps only the map/link helpers below, which mirror
+    // sanitize() logic that still lives inline in the FormRequest classes.
 
-    // --- SaveMapRequest node-label sanitization (strip_tags + trim) ---
-    // Mirrors SaveMapRequest::sanitize() nodes.*.label block. Production does
-    // NOT htmlspecialchars-encode labels (the embed/editor views escape at
-    // render time via escapeHtml/textContent), so this helper does not either.
-
-    private function sanitizeNodeData(array $data): array
-    {
-        if (isset($data['label']) && is_string($data['label'])) {
-            $data['label'] = strip_tags(trim($data['label']));
-        }
-        return $data;
-    }
-
-    public function test_node_label_strips_html(): void
-    {
-        $data = $this->sanitizeNodeData(['label' => '<img src=x onerror=alert(1)>Router-1']);
-        $this->assertEquals('Router-1', $data['label']);
-    }
-
-    public function test_node_label_strips_tags_keeps_special_chars(): void
-    {
-        $data = $this->sanitizeNodeData(['label' => 'Router "Core" & <Main>']);
-        // strip_tags removes <Main>; quotes/ampersand are left raw because
-        // production escapes at render time (escapeHtml/textContent), not here.
-        $this->assertEquals('Router "Core" & ', $data['label']);
-    }
-
-    public function test_node_label_preserves_normal_text(): void
-    {
-        $data = $this->sanitizeNodeData(['label' => 'Core-Router-01']);
-        $this->assertEquals('Core-Router-01', $data['label']);
-    }
-
-    public function test_node_label_handles_unicode(): void
-    {
-        $data = $this->sanitizeNodeData(['label' => 'Routeur-Réseau']);
-        $this->assertEquals('Routeur-Réseau', $data['label']);
-    }
 
     // --- Edge cases ---
 
@@ -96,10 +64,10 @@ class SanitizationTest extends TestCase
     {
         $map = $this->sanitizeMapData(['name' => '']);
         $this->assertEquals('', $map['name']);
-
-        $node = $this->sanitizeNodeData(['label' => '']);
-        $this->assertEquals('', $node['label']);
     }
+
+    // Node-label empty-string and script-injection cases are covered by
+    // NodeLabelNormalizerTest (real class, no mirror).
 
     public function test_nested_tags_fully_stripped(): void
     {
@@ -107,11 +75,9 @@ class SanitizationTest extends TestCase
         $this->assertEquals('clean', $data['name']);
     }
 
-    public function test_script_injection_fully_stripped(): void
-    {
-        $data = $this->sanitizeNodeData(['label' => '<script>document.cookie</script>Node']);
-        $this->assertEquals('document.cookieNode', $data['label']);
-    }
+    // test_script_injection_fully_stripped removed — covered by
+    // NodeLabelNormalizerTest::test_normalize_strips_script_tags.
+
 
     // --- SaveMapRequest link style sanitization ---
 


### PR DESCRIPTION
## Summary

Removes a drifted-mirror test helper from `SanitizationTest` now that the node-label normalization logic has a shared, directly-testable home in `NodeLabelNormalizer` (PR #28).

## Background

`SanitizationTest::sanitizeNodeData()` was a standalone reimplementation of `SaveMapRequest`'s old inline `strip_tags(trim())` logic — a mirror that could drift from production. PR #27's changelog acknowledged this: "SanitizationTest keeps its own `sanitizeNodeData` helper." PR #28 extracted `NodeLabelNormalizer` with `NodeLabelNormalizerTest` (17 cases against the actual class), making the mirror redundant.

## What changed

Removed from `tests/SanitizationTest.php`:
- The `sanitizeNodeData()` private helper (mirrored `strip_tags(trim())`)
- 6 duplicate tests: `test_node_label_strips_html`, `test_node_label_strips_tags_keeps_special_chars`, `test_node_label_preserves_normal_text`, `test_node_label_handles_unicode`, the node-label portion of `test_empty_string_sanitization`, and `test_script_injection_fully_stripped`

All removed cases are covered by `NodeLabelNormalizerTest` against the real `NodeLabelNormalizer` class, not a copy.

`SanitizationTest` keeps its `sanitizeMapData`/`sanitizeLinkData` helpers — those mirror `sanitize()` logic that still lives inline in the FormRequest classes (not yet extracted). Comments point to where node-label coverage now lives.

## Verification

- `phpunit tests/SanitizationTest.php`: **18 tests, 22 assertions — OK**
- `phpunit tests/NodeLabelNormalizerTest.php`: **17 tests — OK** (unchanged)
- Full suite: **305 tests, 931 assertions, 1 skipped — green** (was 310 before; 5 node-label tests dropped as duplicates)
