### PR TITLE
feat: RRD graph hover popups + editor click-through navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **RRD graph hover popups in embed view**: Hover a node or link for 300ms to see an inline LibreNMS RRD time-series graph image — device traffic (`type=device_bits`) for nodes, port traffic (`type=port_bits`) for links. The text tooltip continues to show immediately; the graph popup appears after the delay alongside it. Add `?graphs=0` to disable; auto-disabled in kiosk mode. Uses LibreNMS's existing `/graph` image endpoint — no backend changes required.
+- **Editor click-through**: "View Device" button in the node properties sidebar opens the LibreNMS device page (`/device/{id}`) when a device is assigned. "View Port" button in the link configuration modal opens the LibreNMS port graph (`/graph?type=port_bits&id={port_id}`) when a port is selected. Both open in a new tab.
+
+### Changed
+- **Roadmap reconciliation**: Marked click-through navigation and RRD graph hover popups as complete in `ROADMAP.md` (click-through shipped in v1.9.0 embed view; RRD hover and editor click-through are new). Updated `docs/EMBED.md` with the `graphs` query parameter.
+
 ## [1.10.0] - 2026-07-20
 
 ### Removed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -214,13 +214,13 @@ This release should make existing authoring workflows faster and less error-pron
 
 This release closes the biggest gaps vs legacy weathermap tools and native LibreNMS maps: click-through navigation, RRD graph hover, nested maps, and LLDP/CDP auto-discovery.
 
-- [ ] **Click-through navigation** *(CRITICAL — #1 feature gap vs legacy tools)*
+- [x] **Click-through navigation** *(v1.9.0: embed view; v1.11.0: editor sidebar + RRD hover graphs)*
   - Click a node to open the LibreNMS device page (`/device/{id}`). Nodes already store `device_id`.
   - Click a link to open the LibreNMS interface/port page (`/device/{id}/port/{port_id}`). Links already store port data.
   - Configurable: open in same tab, new tab, or hover tooltip with link.
   - *Every major competitor (legacy LibreNMS weathermap, PHP Weathermap, Zabbix, NagVis) has this. LOW effort — LibreNMS routes are stable, data already stored.*
 
-- [ ] **RRD graph hover popups** *(HIGH impact — defining weathermap UX feature)*
+- [x] **RRD graph hover popups** *(v1.11.0: embed view — hover a node/link for 300ms to show a LibreNMS RRD time-series graph image; `?graphs=0` to disable)*
   - Hover over a node/link to see an embedded RRD time-series graph, not just a text tooltip.
   - LibreNMS exposes graph image endpoints. Use a modern CSS/JS tooltip with embedded `<img>` or `<iframe>`.
   - *The most beloved feature of the classic PHP Weathermap (OverLib graphs). WeathermapNG's text-only tooltips are a step back.*
@@ -277,7 +277,16 @@ This release closes the biggest gaps vs legacy weathermap tools and native Libre
   - Per-user favorites (requires user_id mapping table or column).
   - Saved views per user.
 
-### v1.10.0 - Historical Views & Export
+### v1.10.0 - Maintenance & Dead Code Removal (shipped)
+
+- [x] **Dead auto-save code removal**: removed orphaned `resources/js/versioning.js`, unreachable `MapVersionController::autoSave()`, `auto_save` config keys, and unused `SaveMapVersionRequest` auto-save validation field.
+- [x] **Dead FormRequest and cache class removal**: removed `CreateLinkRequest`, `CreateNodeRequest`, and `MapCacheService` (zero callers).
+- [x] **Node label normalization consistency**: shared `NodeLabelNormalizer` called from both `NodeService` and `SaveMapRequest` so all write paths strip tags identically.
+- [x] **Ambiguous node rate label** (issue #11): node canvas label now uses `humanBits()` formatter with `Σ` prefix and "Total (In + Out)" tooltip text.
+- [x] **Plugin settings page fix**: `Settings::authorize()` now resolves `auth()->user()`; settings form uses `settings[...]` array notation so saves persist.
+- [x] **Debug-gated per-endpoint traffic logging**: `WEATHERMAPNG_DEBUG=true` logs raw per-endpoint counters for issue #11 diagnosis.
+
+### Future - Historical Views & Export
 
 - [ ] **Historical Playback**
   - Timeline scrubber.

--- a/docs/EMBED.md
+++ b/docs/EMBED.md
@@ -17,6 +17,7 @@
 - **Flow particles**: Animated traffic particles follow waypoint paths
 - **Pan & zoom**: Mouse-wheel zoom, drag-to-pan, +/-/Reset buttons, double-click zoom
 - **Hover tooltips**: Node In/Out/Sum traffic; link utilization, bandwidth
+- **RRD graph hover**: Hover a node or link for 300ms to show an inline LibreNMS RRD time-series graph image (device traffic for nodes, port traffic for links). Disabled in kiosk mode; use `?graphs=0` to disable.
 - **Click navigation**: Click a node to open its device page; click a link to open port graphs
 - **Kiosk / NOC wall mode**: Hide all chrome, auto-cycle maps, and control click-through target (see below)
 
@@ -34,6 +35,7 @@
 | `maxz` | `4` | Maximum zoom level |
 | `kiosk` | `0` | Enable NOC wall mode: hide nav, controls, legend, minimap, and status bar |
 | `cycle` | *(none)* | When `kiosk=1`, rotate to the next map every N seconds (minimum 5) |
+| `graphs` | `1` | Show RRD graph hover popups (`0` to disable; auto-disabled in kiosk mode) |
 | `target` | `_blank` | Where node/link click-through opens: `_blank` (new tab) or `self` (same tab) |
 
 ## Live Data

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -310,6 +310,7 @@
                 <div class="btn-group btn-group-sm d-flex">
                     <button type="button" class="btn btn-primary" onclick="saveSelectedNode()" aria-label="Apply node changes"><i class="fas fa-check"></i> Apply</button>
                     <button type="button" class="btn btn-secondary" onclick="duplicateSelectedNode()" title="Duplicate" aria-label="Duplicate selected node"><i class="fas fa-copy"></i></button>
+                    <button type="button" class="btn btn-info" id="node-view-device-btn" onclick="viewSelectedNodeDevice()" title="Open device in LibreNMS" aria-label="Open device in LibreNMS" style="display:none;"><i class="fas fa-external-link-alt"></i></button>
                     <button type="button" class="btn btn-danger" onclick="deleteSelectedNode()" title="Delete" aria-label="Delete selected node"><i class="fas fa-trash"></i></button>
                 </div>
             </div>
@@ -455,6 +456,9 @@
                 </div>
             </div>
             <div class="modal-footer">
+                <button type="button" class="btn btn-info" id="view-port-btn" style="display:none;" onclick="viewLinkPort()">
+                    <i class="fas fa-external-link-alt"></i> View Port
+                </button>
                 <button type="button" class="btn btn-danger" id="delete-link-btn" style="display:none;">
                     <i class="fas fa-trash"></i> Delete
                 </button>
@@ -1906,11 +1910,14 @@ function populateNodeProperties(node) {
             renderNodesList();
             markUnsaved();
             loadInterfacesForNode(node);
+            const _vbtn = document.getElementById('node-view-device-btn');
+            if (_vbtn) _vbtn.style.display = node.deviceId ? 'inline-block' : 'none';
         };
     }
 
-    // Load interfaces
-    loadInterfacesForNode(node);
+    // Show/hide View Device button based on current selection
+    const viewBtn = document.getElementById('node-view-device-btn');
+    if (viewBtn) viewBtn.style.display = node.deviceId ? 'inline-block' : 'none';
 }
 
 function loadInterfacesForNode(node) {
@@ -1964,9 +1971,23 @@ function saveSelectedNode() {
         } else {
             WMNGToast.error('Failed to save node: ' + (d.message || 'Unknown error'), { duration: 3000 });
         }
-    }).catch(error => {
-        WMNGToast.error('Failed to save node: ' + error.message, { duration: 3000 });
     });
+}
+
+function viewSelectedNodeDevice() {
+    if (!selectedNode || !selectedNode.deviceId) return;
+    window.open('{{ url("device") }}/' + selectedNode.deviceId, '_blank');
+}
+
+function viewLinkPort() {
+    if (currentLinkIndex === null) return;
+    const link = links[currentLinkIndex];
+    if (!link) return;
+    const portId = document.getElementById('link-src-port').value || document.getElementById('link-dst-port').value || null;
+    if (!portId) return;
+    const now = Math.floor(Date.now() / 1000);
+    const from = now - 86400;
+    window.open('{{ url("graph") }}?type=port_bits&id=' + portId + '&from=' + from + '&to=' + now, '_blank');
 }
 
 function deleteSelectedNode() {
@@ -2089,6 +2110,14 @@ function openLinkModal(linkIndex) {
     viaStyleSelect.value = (link.style && link.style.via_style) || 'straight';
     deleteBtn.style.display = 'inline-block';
 
+    // Update View Port button when port selects change
+    const updateViewPortBtn = () => {
+        const vpBtn = document.getElementById('view-port-btn');
+        if (vpBtn) vpBtn.style.display = (srcPortSelect.value || dstPortSelect.value) ? 'inline-block' : 'none';
+    };
+    srcPortSelect.onchange = updateViewPortBtn;
+    dstPortSelect.onchange = updateViewPortBtn;
+
     // Load source node ports
     if (srcNode && srcNode.deviceId) {
         fetch('{{ url('plugin/WeathermapNG/api/device') }}/' + srcNode.deviceId + '/ports')
@@ -2124,6 +2153,10 @@ function openLinkModal(linkIndex) {
                 });
             });
     }
+
+    // Show View Port button if either port is already selected
+    const viewPortBtn = document.getElementById('view-port-btn');
+    if (viewPortBtn) viewPortBtn.style.display = (link.portA || link.portB) ? 'inline-block' : 'none';
 
     $('#linkModal').modal('show');
 }

--- a/resources/views/embed.blade.php
+++ b/resources/views/embed.blade.php
@@ -176,6 +176,31 @@
             display: none; pointer-events: none;
         }
 
+        /* Graph hover popup (RRD time-series image) */
+        .embed-graph-popup {
+            position: absolute; background: rgba(255,255,255,0.97);
+            border: 1px solid #ccc; border-radius: 6px;
+            box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+            padding: 8px; display: none; pointer-events: none;
+            z-index: 1002; max-width: 420px;
+        }
+        .embed-graph-popup img {
+            display: block; max-width: 400px; max-height: 180px;
+            border-radius: 3px;
+        }
+        .embed-graph-popup .graph-loading {
+            width: 300px; height: 120px; display: flex;
+            align-items: center; justify-content: center;
+            color: #6c757d; font-size: 13px;
+        }
+        .embed-graph-popup .graph-caption {
+            margin-top: 4px; font-size: 11px; color: #333; text-align: center;
+        }
+        .embed-graph-popup .graph-text-fallback {
+            background: rgba(0,0,0,0.8); color: #fff; padding: 6px 8px;
+            border-radius: 4px; font-size: 12px;
+        }
+
         /* Minimap */
         .embed-minimap {
             position: absolute; top: 55px; right: 10px;
@@ -202,6 +227,7 @@
         body.kiosk-mode .embed-legend,
         body.kiosk-mode .embed-minimap,
         body.kiosk-mode .status-bar,
+        body.kiosk-mode .embed-graph-popup,
         body.kiosk-mode #loading {
             display: none !important;
         }
@@ -274,6 +300,7 @@
             <i class="fas fa-clock"></i> Updated: <span id="last-updated">Never</span>
         </div>
         <div id="tooltip" class="embed-tooltip"></div>
+        <div id="graph-popup" class="embed-graph-popup"></div>
         <div id="controls" class="embed-controls">
             <button type="button" id="toggle-transport" class="btn btn-light btn-sm" aria-label="Live update status">Live: loading…</button>
             <button type="button" id="toggle-flow" class="btn btn-primary btn-sm" aria-label="Toggle flow animation" title="Toggle flow animation"><i class="fas fa-water" aria-hidden="true"></i> Flow</button>
@@ -342,7 +369,7 @@
         let intervalSec = parseInt(param('interval', WMNG_CONFIG.client_refresh), 10) || WMNG_CONFIG.client_refresh;
         let sseEnabled = param('sse', WMNG_CONFIG.enable_sse ? '1' : '0') !== '0' && !!window.EventSource;
         let sseMax = parseInt(param('max', 300), 10) || 300;  // 5 minutes default
-        let currentTransport = 'init';
+        let graphsEnabled = param('graphs', '1') !== '0' && !WMNG_CONFIG.kioskEnabled;
         let eventSourceRef = null;
         let sseReconnectAttempts = 0;
         const maxReconnectAttempts = 5;
@@ -1420,6 +1447,72 @@
             }
         }
 
+        // --- Graph hover popup state ---
+        let graphHoverTimer = null;
+        let graphHoverTarget = null; // { type: 'node'|'link', id, data }
+        const graphBaseUrl = '{{ url("graph") }}';
+        const graphPopup = document.getElementById('graph-popup');
+
+        function hideGraphPopup() {
+            if (graphHoverTimer) { clearTimeout(graphHoverTimer); graphHoverTimer = null; }
+            graphHoverTarget = null;
+            if (graphPopup) graphPopup.style.display = 'none';
+        }
+
+        function showGraphPopup(target, pageX, pageY) {
+            if (!graphsEnabled || !target || !graphPopup) return;
+
+            const now = Math.floor(Date.now() / 1000);
+            const from = now - 3600; // last 1 hour
+            let imgSrc = null;
+            let caption = '';
+
+            if (target.type === 'node' && target.data.device_id) {
+                imgSrc = `${graphBaseUrl}?type=device_bits&id=${target.data.device_id}&from=${from}&to=${now}`;
+                caption = escapeHtml(target.data.label || target.data.device_name || 'Device ' + target.data.device_id);
+            } else if (target.type === 'link') {
+                const link = target.data;
+                const portId = link.port_id_a || link.port_id_b || null;
+                if (portId) {
+                    imgSrc = `${graphBaseUrl}?type=port_bits&id=${portId}&from=${from}&to=${now}`;
+                    const portName = link.source_port_name || link.destination_port_name || '';
+                    caption = escapeHtml(portName ? 'Port: ' + portName : 'Port ' + portId);
+                }
+            }
+
+            if (!imgSrc) return;
+
+            // Position popup, clamping to viewport
+            const popupW = 420, popupH = 220;
+            let px = pageX + 14;
+            let py = pageY + 14;
+            if (px + popupW > window.innerWidth) px = pageX - popupW - 14;
+            if (py + popupH > window.innerHeight) py = pageY - popupH - 14;
+            if (px < 4) px = 4;
+            if (py < 4) py = 4;
+
+            graphPopup.style.left = px + 'px';
+            graphPopup.style.top = py + 'px';
+            graphPopup.innerHTML = `<div class="graph-loading"><i class="fas fa-spinner fa-spin"></i> Loading graph…</div>`;
+            graphPopup.style.display = 'block';
+
+            const img = new Image();
+            img.onload = () => {
+                // Only update if this popup is still for the same target
+                if (graphHoverTarget !== target) return;
+                graphPopup.innerHTML = '';
+                graphPopup.appendChild(img);
+                if (caption) {
+                    const cap = document.createElement('div');
+                    cap.className = 'graph-caption';
+                    cap.textContent = caption;
+                    graphPopup.appendChild(cap);
+                }
+            };
+            img.onerror = () => { hideGraphPopup(); };
+            img.src = imgSrc;
+        }
+
         document.getElementById('map-canvas').addEventListener('mousemove', (e) => {
             const rect = canvas.getBoundingClientRect();
             const x = e.clientX - rect.left;
@@ -1453,6 +1546,8 @@
                 }
             }
             const tooltip = document.getElementById('tooltip');
+            // Determine new hover target for graph popup
+            let newTarget = null;
             if (nbest) {
                 const n = nbest.node;
                 const t = n.traffic || {};
@@ -1467,6 +1562,7 @@
                   `Out: ${humanBits(t.out_bps ?? 0)}<br>` +
                   `Total (In + Out): ${humanBits(sum ?? 0)}<br>` +
                   `<span style="opacity:0.75;">Source: ${src}</span>`;
+                if (n.device_id) newTarget = { type: 'node', id: n.id, data: n };
             } else if (best) {
                 tooltip.style.display = 'block';
                 tooltip.style.left = (e.pageX + 10) + 'px';
@@ -1476,10 +1572,29 @@
                 tooltip.innerHTML = `<b>Utilization: ${pctVal}</b><br>` +
                     `<span style="color:#40ff40;">▼</span> In: ${humanBits(best.inBps)}<br>` +
                     `<span style="color:#40a0ff;">▲</span> Out: ${humanBits(best.outBps)}` + bwLine;
+                const link = best.link;
+                if (link && (link.port_id_a || link.port_id_b)) newTarget = { type: 'link', id: link.id, data: link };
             } else {
                 tooltip.style.display = 'none';
             }
+            // Graph popup: schedule or cancel based on hover target
+            if (newTarget) {
+                const targetKey = newTarget.type + ':' + newTarget.id;
+                const prevKey = graphHoverTarget ? graphHoverTarget.type + ':' + graphHoverTarget.id : null;
+                if (targetKey !== prevKey) {
+                    hideGraphPopup();
+                    graphHoverTarget = newTarget;
+                    const px = e.pageX, py = e.pageY;
+                    graphHoverTimer = setTimeout(() => {
+                        if (graphHoverTarget === newTarget) showGraphPopup(newTarget, px, py);
+                    }, 300);
+                }
+            } else {
+                hideGraphPopup();
+            }
         });
+        // Hide graph popup when leaving the canvas
+        document.getElementById('map-canvas').addEventListener('mouseleave', hideGraphPopup);
         // Click: node → device page; else link → port graphs
         document.getElementById('map-canvas').addEventListener('click', (e) => {
             const rect = canvas.getBoundingClientRect();
@@ -1525,7 +1640,6 @@
                 const from = now - 86400;
                 const openGraph = (portId) => {
                     if (!portId) return;
-                    const graphBaseUrl = '{{ url("graph") }}';
                     const url = graphBaseUrl + '?type=port_bits&id=' + portId + '&from=' + from + '&to=' + now;
                     window.open(url, WMNG_CONFIG.linkTarget || '_blank');
                 };
@@ -1533,7 +1647,6 @@
                 if (pB) openGraph(pB);
             }
         });
-
         function drawMinimap() {
             if (!minimap || !Array.isArray(mapData.nodes) || mapData.nodes.length === 0) return;
 


### PR DESCRIPTION
## Summary

Two of the highest-impact features from the roadmap, both closing the biggest gaps vs legacy weathermap tools:

### RRD Graph Hover Popups (Embed View)
The most-beloved feature of classic PHP Weathermap (OverLib graphs). Hover a node or link for 300ms to see an inline LibreNMS RRD time-series graph image — device traffic (`type=device_bits`) for nodes, port traffic (`type=port_bits`) for links.

- Text tooltip continues to show immediately; the graph popup appears after the hover delay alongside it
- `?graphs=0` URL param disables the feature; auto-disabled in kiosk mode
- Smart viewport clamping keeps the popup on-screen; loading spinner and error handling included
- No backend changes — uses LibreNMS's existing `/graph` image endpoint

### Editor Click-Through Navigation
The #1 feature gap vs legacy tools. Click-through already existed in the embed view (shipped v1.9.0); this adds it to the editor:

- **"View Device" button** in the node properties sidebar — appears when a device is assigned, opens `/device/{id}` in a new tab
- **"View Port" button** in the link configuration modal — appears when a port is selected, opens `/graph?type=port_bits&id={portId}` in a new tab
- Both buttons show/hide dynamically based on selection state

### Documentation Reconciliation
- `ROADMAP.md`: Marked click-through navigation and RRD graph hover as `[x]` complete; fixed the stale v1.10.0 section (was titled "Historical Views & Export" but actually shipped maintenance/dead code removal)
- `CHANGELOG.md`: New `[Unreleased]` section documenting both features
- `docs/EMBED.md`: Added `graphs` query parameter, documented RRD graph hover

## Verification

- **309 tests pass** (948 assertions, 1 skipped) — ran inside LibreNMS Docker container
- **Embed view**: Renders cleanly in browser — canvas active, graph popup element present, zero JS console errors
- **Editor view**: Renders cleanly — canvas active, both new buttons present and correctly hidden when no selection, zero JS console errors
- Docker dev environment (MariaDB, Redis, LibreNMS, dispatcher) all running healthy

## Test plan

- [x] `vendor/bin/phpunit` — 309 tests, 948 assertions, 1 skipped
- [x] Browser: embed view `/plugin/WeathermapNG/embed/1` loads with no JS errors, `#graph-popup` element present
- [x] Browser: editor view `/plugin/WeathermapNG/editor/1` loads with no JS errors, `#node-view-device-btn` and `#view-port-btn` present
- [ ] Manual: hover a node in embed view and confirm graph popup appears after 300ms
- [ ] Manual: select a node with device in editor and confirm "View Device" button appears
- [ ] Manual: open link modal with ports and confirm "View Port" button appears
