### PR TITLE
feat: CLI commands, editor autocomplete + status, embed canvas layer separation, backend perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+- **CLI commands for map management**: Four new `lnms` commands — `weathermapng:create-map`, `weathermapng:list-maps`, `weathermapng:export`, `weathermapng:discover`. Registered via Artisan through the plugin's ServiceProvider. Reuses existing `MapService::createMap()` and `Map::toJsonModel()` — no backend refactoring needed.
+- **Editor device autocomplete**: Device selection in the editor now uses a debounced search input with live dropdown results from the existing `/api/devices?q=` endpoint (LIMIT 20, cached 300s). Replaces the full device list `<select>` that loaded every device into the DOM. Also applies to the node properties "Change" device flow.
+- **Editor status-aware node colors**: Editor nodes now reflect device status — green (up), red (down), gray (unknown) — using the `status` field already present in the JSON payload but previously discarded. Down nodes get a red dashed ring.
 - **RRD graph hover popups in embed view**: Hover a node or link for 300ms to see an inline LibreNMS RRD time-series graph image — device traffic (`type=device_bits`) for nodes, port traffic (`type=port_bits`) for links. The text tooltip continues to show immediately; the graph popup appears after the delay alongside it. Add `?graphs=0` to disable; auto-disabled in kiosk mode. Uses LibreNMS's existing `/graph` image endpoint — no backend changes required.
 - **Editor click-through**: "View Device" button in the node properties sidebar opens the LibreNMS device page (`/device/{id}`) when a device is assigned. "View Port" button in the link configuration modal opens the LibreNMS port graph (`/graph?type=port_bits&id={port_id}`) when a port is selected. Both open in a new tab.
 
@@ -27,7 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`bin/map-poller.php` file locking**: Added `LOCK_EX` to cache-file `file_put_contents`.
 
 ### Performance
-- **`nodeById` Map lookup in embed view**: `drawLink()` now uses a prebuilt `Map` instead of `Array.find()` — eliminates O(L×N) per-frame lookups at 60fps.
+- **Canvas layer separation in embed view**: Static content (background, links, nodes, labels) now renders on the main canvas while dynamic content (particles, dash animations) renders on a separate overlay canvas. The animation loop only redraws the overlay when static content hasn't changed — eliminates 60fps full-canvas redraws.
+- **RAF pause on zero traffic**: The animation loop pauses entirely when no link has active traffic, eliminating unnecessary CPU usage. Restarts automatically when traffic appears in a live update.
+- **O(N×L)→O(L) node→links index in `NodeDataService`**: `sumPortTraffic()` now uses a pre-built `nodeId → Link[]` index instead of iterating all links per node. For a 200-node, 300-link map: 60,000 iterations → ~600.
+- **Batch link validation in `LinkService::storeLinks`**: Pre-fetches all referenced nodes and ports in 2 queries instead of 2L+P per-link queries. Validation does array lookups against the pre-fetched maps.
 - **Decoupled minimap from animation loop**: `renderMap(skipMinimap)` — the 60fps animation tick no longer redraws the minimap. Minimap updates only on state changes (live updates, pan/zoom, resize).
 
 ## [1.10.0] - 2026-07-20

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -122,6 +122,26 @@
     color: var(--editor-input-text); box-shadow: 0 0 0 0.2rem rgba(13,110,253,0.25);
 }
 
+/* Device autocomplete */
+.ac-wrap { position: relative; }
+.ac-input { font-size: 12px; background: var(--editor-input-bg); border: 1px solid var(--editor-input-border);
+    color: var(--editor-input-text); padding: 4px 8px; border-radius: 4px; width: 100%; box-sizing: border-box; }
+.ac-input:focus { outline: none; border-color: var(--editor-accent); box-shadow: 0 0 0 0.2rem rgba(13,110,253,0.25); }
+.ac-dropdown { position: absolute; left: 0; right: 0; top: 100%; max-height: 220px; overflow-y: auto;
+    background: var(--editor-sidebar-bg); border: 1px solid var(--editor-input-border); border-radius: 4px;
+    z-index: 1200; display: none; box-shadow: 0 4px 10px rgba(0,0,0,0.2); }
+.ac-dropdown.show { display: block; }
+.ac-item { padding: 6px 10px; font-size: 12px; color: var(--editor-text); cursor: pointer; white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis; }
+.ac-item:hover, .ac-item.active { background: var(--editor-list-hover); }
+.ac-empty { padding: 8px 10px; font-size: 11px; color: var(--editor-text-muted); font-style: italic; }
+.ac-loading { padding: 8px 10px; font-size: 11px; color: var(--editor-text-muted); }
+.ac-status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; vertical-align: middle; }
+.ac-device-name { font-size: 12px; color: var(--editor-text); flex: 1; min-width: 0;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding: 4px 8px; }
+.ac-change-btn { font-size: 11px; padding: 2px 6px; margin-left: 4px; cursor: pointer; flex-shrink: 0; }
+.ac-selected-row { display: flex; align-items: center; gap: 4px; }
+
 /* Node/link list items */
 #nodes-list > div:hover, #links-list > div:hover {
     background-color: var(--editor-list-hover); border-radius: 3px;
@@ -269,9 +289,13 @@
             <div class="panel-body">
                 <div class="form-group mb-2">
                     <label class="form-label">Device</label>
-                    <select class="form-control form-control-sm" id="device-select">
-                        <option value="">Select device...</option>
-                    </select>
+                    <div class="ac-wrap" id="device-ac-wrap">
+                        <input type="text" class="ac-input" id="device-search"
+                            placeholder="Search devices..." autocomplete="off" role="combobox"
+                            aria-expanded="false" aria-autocomplete="list" aria-controls="device-ac-results">
+                        <input type="hidden" id="device-select" value="">
+                        <div class="ac-dropdown" id="device-ac-results" role="listbox"></div>
+                    </div>
                 </div>
                 <div class="form-group mb-2" id="interface-container" style="display: none;">
                     <label class="form-label">Interface</label>
@@ -297,9 +321,18 @@
                 </div>
                 <div class="form-group mb-2">
                     <label class="form-label">Device</label>
-                    <select class="form-control form-control-sm" id="node-prop-device">
-                        <option value="">No device</option>
-                    </select>
+                    <div class="ac-selected-row">
+                        <span class="ac-device-name" id="node-prop-device-name">No device</span>
+                        <input type="hidden" id="node-prop-device" value="">
+                        <button type="button" class="btn btn-sm btn-outline-secondary ac-change-btn"
+                            id="node-prop-device-change" onclick="openNodeDeviceAutocomplete()">Change</button>
+                    </div>
+                    <div class="ac-wrap" id="node-device-ac-wrap" style="display:none;">
+                        <input type="text" class="ac-input" id="node-device-search"
+                            placeholder="Search devices..." autocomplete="off" role="combobox"
+                            aria-expanded="false" aria-autocomplete="list" aria-controls="node-device-ac-results">
+                        <div class="ac-dropdown" id="node-device-ac-results" role="listbox"></div>
+                    </div>
                 </div>
                 <div class="form-group mb-2">
                     <label class="form-label">Interface</label>
@@ -977,6 +1010,13 @@
                 return nodes.find(node => node.id === id || node.dbId === id);
             }
 
+            function getNodeColor(node) {
+                const status = node.status || 'unknown';
+                if (status === 'down') return '#dc3545';
+                if (status === 'up') return '#28a745';
+                return '#6c757d';  // unknown
+            }
+
             function drawNode(node) {
                 const radius = 12;
                 const defaultNodeStyle = getDefaultNodeStyle();
@@ -989,7 +1029,7 @@
                 } else if (node === selectedNode) {
                     ctx.fillStyle = '#0d6efd'; // Blue for selected
                 } else {
-                    ctx.fillStyle = defaultNodeStyle.color || '#28a745';
+                    ctx.fillStyle = node.status ? getNodeColor(node) : (defaultNodeStyle.color || '#28a745');
                 }
                 ctx.fill();
 
@@ -1004,6 +1044,17 @@
                     ctx.strokeStyle = 'rgba(253, 126, 20, 0.5)';
                     ctx.lineWidth = 2;
                     ctx.stroke();
+                }
+
+                // Draw red dashed ring for down nodes
+                if (node.status === 'down') {
+                    ctx.beginPath();
+                    ctx.arc(node.x, node.y, radius + 4, 0, Math.PI * 2);
+                    ctx.strokeStyle = 'rgba(220, 53, 69, 0.6)';
+                    ctx.lineWidth = 2;
+                    ctx.setLineDash([3, 2]);
+                    ctx.stroke();
+                    ctx.setLineDash([]);
                 }
 
                 // Use theme-aware text color for labels with shadow for readability
@@ -1506,6 +1557,8 @@
                         x: node.x,
                         y: node.y,
                         deviceId: node.device_id,
+                        deviceName: node.device_name || null,
+                        status: node.status || null,
                         interfaceId: node.meta?.interface_id || null,
                     }));
 
@@ -1552,50 +1605,168 @@
                 });
             }
 
+            // --- Device autocomplete ---
+            let acSelectedDevice = null;   // currently selected device from the add-node search
+
+            function deviceName(device) {
+                return device.hostname || device.sysName || `Device ${device.device_id}`;
+            }
+
+            function deviceStatusColor(device) {
+                const st = device.status || 'unknown';
+                if (st === 'down') return '#dc3545';
+                if (st === 'up') return '#28a745';
+                return '#6c757d';
+            }
+
             function loadDevices() {
-                const deviceSelect = document.getElementById('device-select');
+                initDeviceAutocomplete('device-search', 'device-ac-results', function(device) {
+                    acSelectedDevice = device;
+                    devicesCache = [device];
+                    document.getElementById('device-select').value = device.device_id;
+                    loadDeviceInterfaces(device.device_id);
+                });
+            }
+
+            function loadDeviceInterfaces(deviceId) {
                 const interfaceSelect = document.getElementById('interface-select');
                 const interfaceContainer = document.getElementById('interface-container');
-                if (!deviceSelect || !interfaceSelect) return;
-
-                deviceSelect.innerHTML = '<option value="">Choose a device...</option>';
-                fetch('{{ url('plugin/WeathermapNG/api/devices') }}')
+                interfaceSelect.innerHTML = '<option value="">Select interface...</option>';
+                if (!deviceId) {
+                    if (interfaceContainer) interfaceContainer.style.display = 'none';
+                    return;
+                }
+                if (interfaceContainer) interfaceContainer.style.display = 'block';
+                fetch(`{{ url('plugin/WeathermapNG/api/device') }}/${deviceId}/ports`)
                     .then(r => {
-                        if (!r.ok) { console.warn('Failed to load devices: HTTP ' + r.status); return []; }
+                        if (!r.ok) { console.warn('Failed to load ports: HTTP ' + r.status); return { ports: [] }; }
                         return r.json();
                     })
                     .then(data => {
-                        const devices = Array.isArray(data) ? data : (data.devices || []);
-                        devicesCache = devices;
-                        devices.forEach(device => {
+                        (data.ports || []).forEach(port => {
                             const option = document.createElement('option');
-                            option.value = device.device_id;
-                            option.textContent = device.hostname || device.sysName || `Device ${device.device_id}`;
-                            deviceSelect.appendChild(option);
+                            option.value = port.port_id;
+                            option.textContent = port.ifName || port.ifIndex || `Port ${port.port_id}`;
+                            interfaceSelect.appendChild(option);
                         });
                     });
+            }
 
-                deviceSelect.addEventListener('change', function() {
-                    const deviceId = this.value;
-                    interfaceSelect.innerHTML = '<option value="">Choose an interface...</option>';
-                    if (!deviceId) {
-                        if (interfaceContainer) interfaceContainer.style.display = 'none';
+            function initDeviceAutocomplete(searchId, resultsId, onSelect) {
+                const search = document.getElementById(searchId);
+                const dropdown = document.getElementById(resultsId);
+                if (!search || !dropdown) return;
+
+                let localResults = [];
+                let localActive = -1;
+                let localTimer = null;
+
+                function setItems(devices) {
+                    localResults = devices;
+                    devicesCache = devices;
+                    localActive = -1;
+                    dropdown.innerHTML = '';
+                    if (!devices.length) {
+                        const empty = document.createElement('div');
+                        empty.className = 'ac-empty';
+                        empty.textContent = 'No devices found';
+                        dropdown.appendChild(empty);
+                    } else {
+                        devices.forEach((dev, i) => {
+                            const item = document.createElement('div');
+                            item.className = 'ac-item' + (i === localActive ? ' active' : '');
+                            item.setAttribute('role', 'option');
+                            const dot = document.createElement('span');
+                            dot.className = 'ac-status-dot';
+                            dot.style.background = deviceStatusColor(dev);
+                            item.appendChild(dot);
+                            item.appendChild(document.createTextNode(deviceName(dev)));
+                            item.addEventListener('mousedown', function(e) {
+                                e.preventDefault();
+                                selectItem(i);
+                            });
+                            dropdown.appendChild(item);
+                        });
+                    }
+                    dropdown.classList.add('show');
+                    search.setAttribute('aria-expanded', 'true');
+                }
+
+                function hide() {
+                    dropdown.classList.remove('show');
+                    search.setAttribute('aria-expanded', 'false');
+                }
+
+                function updateActive() {
+                    const items = dropdown.querySelectorAll('.ac-item');
+                    items.forEach((el, i) => el.classList.toggle('active', i === localActive));
+                    if (localActive >= 0 && items[localActive]) {
+                        items[localActive].scrollIntoView({ block: 'nearest' });
+                    }
+                }
+
+                function selectItem(idx) {
+                    const dev = localResults[idx];
+                    if (!dev) return;
+                    search.value = deviceName(dev);
+                    hide();
+                    onSelect(dev);
+                }
+
+                search.addEventListener('input', function() {
+                    const q = this.value.trim();
+                    clearTimeout(localTimer);
+                    if (q.length < 2) {
+                        hide();
                         return;
                     }
-                    if (interfaceContainer) interfaceContainer.style.display = 'block';
-                    fetch(`{{ url('plugin/WeathermapNG/api/device') }}/${deviceId}/ports`)
-                        .then(r => {
-                            if (!r.ok) { console.warn('Failed to load ports: HTTP ' + r.status); return { ports: [] }; }
-                            return r.json();
-                        })
-                        .then(data => {
-                            (data.ports || []).forEach(port => {
-                                const option = document.createElement('option');
-                                option.value = port.port_id;
-                                option.textContent = port.ifName || port.ifIndex || `Port ${port.port_id}`;
-                                interfaceSelect.appendChild(option);
-                            });
-                        });
+                    localTimer = setTimeout(function() {
+                        dropdown.innerHTML = '<div class="ac-loading">Searching...</div>';
+                        dropdown.classList.add('show');
+                        fetch('{{ url('plugin/WeathermapNG/api/devices') }}?q=' + encodeURIComponent(q))
+                            .then(r => {
+                                if (!r.ok) return [];
+                                return r.json();
+                            })
+                            .then(data => {
+                                const devices = Array.isArray(data) ? data : (data.devices || []);
+                                setItems(devices);
+                            })
+                            .catch(function() { hide(); });
+                    }, 200);
+                });
+
+                search.addEventListener('keydown', function(e) {
+                    if (!dropdown.classList.contains('show')) {
+                        if (e.key === 'ArrowDown' && this.value.trim().length >= 2) {
+                            e.preventDefault();
+                            this.dispatchEvent(new Event('input'));
+                        }
+                        return;
+                    }
+                    if (e.key === 'ArrowDown') {
+                        e.preventDefault();
+                        localActive = Math.min(localActive + 1, localResults.length - 1);
+                        updateActive();
+                    } else if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        localActive = Math.max(localActive - 1, 0);
+                        updateActive();
+                    } else if (e.key === 'Enter') {
+                        e.preventDefault();
+                        if (localActive >= 0) {
+                            selectItem(localActive);
+                        } else if (localResults.length === 1) {
+                            selectItem(0);
+                        }
+                    } else if (e.key === 'Escape') {
+                        e.preventDefault();
+                        hide();
+                    }
+                });
+
+                search.addEventListener('blur', function() {
+                    setTimeout(hide, 150);
                 });
             }
 
@@ -1607,7 +1778,7 @@
                 const interfaceSelect = document.getElementById('interface-select');
                 const deviceId = deviceSelect?.value ? parseInt(deviceSelect.value, 10) : null;
                 const interfaceId = interfaceSelect?.value ? parseInt(interfaceSelect.value, 10) : null;
-                const device = devicesCache.find(d => d.device_id === deviceId);
+                const device = acSelectedDevice || devicesCache.find(d => d.device_id === deviceId);
                 const label = device?.hostname || device?.sysName || `Node ${nodes.length + 1}`;
 
                 // Smart placement: spiral outward from center to avoid overlap
@@ -1630,6 +1801,8 @@
                     x: x,
                     y: y,
                     deviceId: deviceId,
+                    deviceName: device ? deviceName(device) : null,
+                    status: device ? (device.status || null) : null,
                     interfaceId: interfaceId,
                 };
 
@@ -1869,8 +2042,6 @@ function exportJson() {
 function populateNodeProperties(node) {
     const card = document.getElementById('node-properties-card');
     const label = document.getElementById('node-prop-label');
-    const devSel = document.getElementById('node-prop-device');
-    const intSel = document.getElementById('node-prop-interface');
 
     if (!node) {
         if (card) card.style.display = 'none';
@@ -1891,33 +2062,50 @@ function populateNodeProperties(node) {
         };
     }
 
-    // Populate device dropdown from cache
-    if (devSel) {
-        devSel.innerHTML = '<option value="">No device</option>';
-        devicesCache.forEach(device => {
-            const opt = document.createElement('option');
-            opt.value = device.device_id;
-            opt.textContent = device.hostname || device.sysName || `Device ${device.device_id}`;
-            if (node.deviceId == device.device_id) opt.selected = true;
-            devSel.appendChild(opt);
-        });
-
-        // Update interface when device changes
-        devSel.onchange = function() {
-            node.deviceId = this.value ? parseInt(this.value, 10) : null;
-            node.interfaceId = null;
-            renderEditor();
-            renderNodesList();
-            markUnsaved();
-            loadInterfacesForNode(node);
-            const _vbtn = document.getElementById('node-view-device-btn');
-            if (_vbtn) _vbtn.style.display = node.deviceId ? 'inline-block' : 'none';
-        };
+    // Populate device display + Change button
+    const devName = document.getElementById('node-prop-device-name');
+    const devHidden = document.getElementById('node-prop-device');
+    const devWrap = document.getElementById('node-device-ac-wrap');
+    if (devHidden) {
+        devHidden.value = node.deviceId || '';
+        if (devName) devName.textContent = node.deviceName || (node.deviceId ? `Device ${node.deviceId}` : 'No device');
+        // Hide any open autocomplete from a previous node
+        if (devWrap) devWrap.style.display = 'none';
     }
 
     // Show/hide View Device button based on current selection
     const viewBtn = document.getElementById('node-view-device-btn');
     if (viewBtn) viewBtn.style.display = node.deviceId ? 'inline-block' : 'none';
+}
+
+function openNodeDeviceAutocomplete() {
+    if (!selectedNode) return;
+    const wrap = document.getElementById('node-device-ac-wrap');
+    const search = document.getElementById('node-device-search');
+    if (!wrap || !search) return;
+    wrap.style.display = 'block';
+    search.value = '';
+    search.focus();
+    // Lazy-init the autocomplete once
+    if (!search.dataset.acReady) {
+        search.dataset.acReady = '1';
+        initDeviceAutocomplete('node-device-search', 'node-device-ac-results', function(device) {
+            selectedNode.deviceId = device.device_id;
+            selectedNode.deviceName = deviceName(device);
+            selectedNode.status = device.status || null;
+            selectedNode.interfaceId = null;
+            const devHidden = document.getElementById('node-prop-device');
+            const devName = document.getElementById('node-prop-device-name');
+            if (devHidden) devHidden.value = device.device_id;
+            if (devName) devName.textContent = deviceName(device);
+            renderEditor();
+            renderNodesList();
+            markUnsaved();
+            loadInterfacesForNode(selectedNode);
+            const _vbtn = document.getElementById('node-view-device-btn');
+            if (_vbtn) _vbtn.style.display = 'inline-block';
+        });
+    }
 }
 
 function loadInterfacesForNode(node) {

--- a/resources/views/embed.blade.php
+++ b/resources/views/embed.blade.php
@@ -27,6 +27,11 @@
             display: block;
         }
 
+        #overlay-canvas {
+            position: absolute;
+            pointer-events: none;
+        }
+
         .loading {
             display: flex;
             flex-direction: column;
@@ -295,6 +300,7 @@
             <div>Loading map...</div>
         </div>
         <canvas id="map-canvas"></canvas>
+        <canvas id="overlay-canvas"></canvas>
         <canvas id="minimap" width="160" height="120" class="embed-minimap"></canvas>
         <div id="status-bar" class="status-bar" style="display: none;">
             <i class="fas fa-clock"></i> Updated: <span id="last-updated">Never</span>
@@ -395,8 +401,10 @@
         }
         // Build the node lookup map from the initial parsed mapData.
         rebuildNodeIndex();
-        let canvas, ctx, minimap;
+        let canvas, ctx, overlayCanvas, overlayCtx, minimap;
         let viewScale = 1, viewOffsetX = 0, viewOffsetY = 0;
+        let staticDirty = true;
+        let hasActiveTraffic = false;
         let animationId;
         let lastUpdate = Date.now();
         let animTick = 0;
@@ -416,6 +424,10 @@
         let flowAnimationEnabled = !reducedMotion;
         let particleDensity = 1.0; // 0.5 to 2.0
         let particleSpeed = 1.0; // 0.5 to 2.0
+        // Compute initial traffic state from any inline live data so the RAF
+        // loop starts animating immediately when the page loads with traffic.
+        hasActiveTraffic = Array.isArray(mapData.links) &&
+            mapData.links.some(l => (l.live?.in_bps > 0 || l.live?.out_bps > 0));
         // nodeById lookup map — rebuilt whenever mapData.nodes changes,
         // eliminates O(L*N) Array.find() per render frame in drawLink.
         let nodeById = new Map();
@@ -442,7 +454,7 @@
                 startLiveUpdates();
                 renderLegend();
                 const ms = document.getElementById('metric-select');
-                if (ms) { ms.value = currentMetric; ms.addEventListener('change', () => { currentMetric = ms.value; renderLegend(); renderMap(); }); }
+                if (ms) { ms.value = currentMetric; ms.addEventListener('change', () => { currentMetric = ms.value; renderLegend(); staticDirty = true; renderMap(); }); }
                 const ex = document.getElementById('export-png');
                 if (ex) ex.addEventListener('click', exportPNG);
                 if (navEnabled) initNavControls();
@@ -451,14 +463,29 @@
             }
         });
 
+        function syncOverlayCanvas() {
+            // Position and size the overlay canvas to exactly match the main canvas.
+            // The main canvas is flex-centered inside #map-container, so we mirror
+            // its rendered offset rather than assuming top-left alignment.
+            const rect = canvas.getBoundingClientRect();
+            const containerRect = canvas.parentElement.getBoundingClientRect();
+            overlayCanvas.style.left = (rect.left - containerRect.left) + 'px';
+            overlayCanvas.style.top = (rect.top - containerRect.top) + 'px';
+            overlayCanvas.width = canvas.width;
+            overlayCanvas.height = canvas.height;
+        }
+
         function initCanvas() {
             canvas = document.getElementById('map-canvas');
             ctx = canvas.getContext('2d');
+            overlayCanvas = document.getElementById('overlay-canvas');
+            overlayCtx = overlayCanvas.getContext('2d');
 
             // Set canvas size
             const container = document.getElementById('map-container');
             canvas.width = container.clientWidth;
             canvas.height = container.clientHeight;
+            syncOverlayCanvas();
             minimap = document.getElementById('minimap');
 
             // Hide loading
@@ -466,7 +493,7 @@
             const bgUrl = mapData.options?.background_image;
             if (bgUrl) {
                 bgImg = new Image();
-                bgImg.onload = () => { renderMap(); };
+                bgImg.onload = () => { staticDirty = true; renderMap(); };
                 bgImg.src = bgUrl;
             }
         }
@@ -478,7 +505,7 @@
             nodeGeoms.length = 0;
             linkGeoms.length = 0;
 
-            // Clear canvas
+            // Clear main canvas
             ctx.clearRect(0, 0, canvas.width, canvas.height);
 
             // Draw background
@@ -509,7 +536,7 @@
             ctx.translate(viewOffsetX, viewOffsetY);
             ctx.scale(viewScale, viewScale);
 
-            // Draw links first (behind nodes)
+            // Draw static link parts (line stroke, color, width, labels, badges)
             if (Array.isArray(mapData.links)) {
                 mapData.links.forEach(link => {
                     drawLink(link);
@@ -525,9 +552,32 @@
 
             ctx.restore();
 
+            // Static layer is now current; only the overlay needs per-frame work.
+            staticDirty = false;
+
+            // Draw dynamic overlay (particles / dash animation) immediately so a
+            // single renderMap() call (e.g. from pan/zoom) shows a complete frame.
+            renderOverlay();
+
             // Update status and overlays
             updateStatus();
             if (!skipMinimap) drawMinimap();
+        }
+
+        // Draw only the dynamic layer (particles / animated dashes) onto the
+        // overlay canvas. Runs every RAF tick; the main canvas is untouched.
+        function renderOverlay() {
+            if (!mapData || !mapData.links) return;
+            overlayCtx.clearRect(0, 0, overlayCanvas.width, overlayCanvas.height);
+            overlayCtx.save();
+            overlayCtx.translate(viewOffsetX, viewOffsetY);
+            overlayCtx.scale(viewScale, viewScale);
+            if (Array.isArray(mapData.links)) {
+                mapData.links.forEach(link => {
+                    drawLinkDynamic(link, overlayCtx);
+                });
+            }
+            overlayCtx.restore();
         }
 
         function initKioskMode() {
@@ -625,6 +675,7 @@
                 const dx = e.clientX - panLastX; const dy = e.clientY - panLastY;
                 panLastX = e.clientX; panLastY = e.clientY;
                 userOffsetX += dx; userOffsetY += dy;
+                staticDirty = true;
                 renderMap();
             });
             window.addEventListener('mouseup', () => { if (isPanning) { isPanning = false; canvas.style.cursor = 'default'; } });
@@ -650,10 +701,11 @@
             const vy = wy * (baseScale * userScale) + baseOffsetY;
             userOffsetX = cx - vx;
             userOffsetY = cy - vy;
+            staticDirty = true;
             renderMap();
         }
 
-        function resetView() { userScale = 1; userOffsetX = 0; userOffsetY = 0; renderMap(); }
+        function resetView() { userScale = 1; userOffsetX = 0; userOffsetY = 0; staticDirty = true; renderMap(); }
         function clamp(v,a,b){ return Math.max(a, Math.min(b, v)); }
 
         const nodeGeoms = [];
@@ -888,35 +940,21 @@
             const y2 = (targetNode.position?.y ?? targetNode.y) || 0;
 
             const { points, viaStyle } = buildLinkPath(link, x1, y1, x2, y2);
-
-            // Draw link line
-            traceLinkPath(ctx, points, viaStyle);
             const metric = getLinkMetric(link);
             const pct = getLinkPct(link, metric);
             const linkStyle = link.style || {};
-            ctx.strokeStyle = (linkStyle.color !== undefined && linkStyle.color !== null) ? linkStyle.color : getLinkColor(pct);
             const width = Math.max(0.5, linkStyle.width || link.width || defaultLinkStyle.width || 2);
-            ctx.lineWidth = width;
-            
-            // Use solid line if flow animation is enabled
-            if (!flowAnimationEnabled) {
-                const dash = Math.max(6, width * 3);
-                ctx.setLineDash([dash, dash]);
-                // Animate dash offset only when motion is not reduced;
-                // otherwise keep the dashed line static for prefers-reduced-motion.
-                if (!reducedMotion) {
-                    const speed = Math.max(0.5, Math.min(5, ((pct ?? 10)) / 20));
-                    ctx.lineDashOffset = -(animTick * speed);
-                }
-            }
-            ctx.stroke();
-            ctx.setLineDash([]);
-            
-            // Draw flow particles if enabled
-            if (flowAnimationEnabled) {
-                drawFlowParticles(link, x1, y1, x2, y2, pct, points);
-            }
 
+            // Draw link line (static). In flow mode the line is solid; in dash
+            // mode the line stroke is delegated to the overlay (drawLinkDynamic)
+            // so the animated dash offset doesn't force a main-canvas redraw.
+            if (flowAnimationEnabled) {
+                traceLinkPath(ctx, points, viaStyle);
+                ctx.strokeStyle = (linkStyle.color !== undefined && linkStyle.color !== null) ? linkStyle.color : getLinkColor(pct);
+                ctx.lineWidth = width;
+                ctx.stroke();
+            }
+            // Dash-mode line and particles are drawn on the overlay by drawLinkDynamic.
             // Link utilization label
             if (metric !== null && metric !== undefined) {
                 const showLabel = (currentMetric === 'percent')
@@ -954,8 +992,47 @@
             // store geometry for hover
             storeLinkGeom(link, x1, y1, x2, y2, pct, points);
         }
+
+        // Draw the dynamic parts of a link onto the overlay canvas:
+        // - flow mode: particles via drawFlowParticles
+        // - dash mode: dashed line stroke with animated lineDashOffset
+        function drawLinkDynamic(link, octx) {
+            const srcId = link.source ?? link.src ?? link.source_id;
+            const dstId = link.target ?? link.dst ?? link.destination_id;
+            const sourceNode = nodeById.get(srcId);
+            const targetNode = nodeById.get(dstId);
+            if (!sourceNode || !targetNode) return;
+
+            const x1 = (sourceNode.position?.x ?? sourceNode.x) || 0;
+            const y1 = (sourceNode.position?.y ?? sourceNode.y) || 0;
+            const x2 = (targetNode.position?.x ?? targetNode.x) || 0;
+            const y2 = (targetNode.position?.y ?? targetNode.y) || 0;
+
+            const { points, viaStyle } = buildLinkPath(link, x1, y1, x2, y2);
+            const metric = getLinkMetric(link);
+            const pct = getLinkPct(link, metric);
+            const linkStyle = link.style || {};
+            const width = Math.max(0.5, linkStyle.width || link.width || defaultLinkStyle.width || 2);
+
+            if (flowAnimationEnabled) {
+                drawFlowParticles(link, x1, y1, x2, y2, pct, points, octx);
+            } else {
+                // Dash-mode: draw the dashed line with animated offset.
+                traceLinkPath(octx, points, viaStyle);
+                octx.strokeStyle = (linkStyle.color !== undefined && linkStyle.color !== null) ? linkStyle.color : getLinkColor(pct);
+                octx.lineWidth = width;
+                const dash = Math.max(6, width * 3);
+                octx.setLineDash([dash, dash]);
+                if (!reducedMotion) {
+                    const speed = Math.max(0.5, Math.min(5, ((pct ?? 10)) / 20));
+                    octx.lineDashOffset = -(animTick * speed);
+                }
+                octx.stroke();
+                octx.setLineDash([]);
+            }
+        }
         
-        function drawFlowParticles(link, x1, y1, x2, y2, pct, pathPoints) {
+        function drawFlowParticles(link, x1, y1, x2, y2, pct, pathPoints, drawCtx) {
             const live = link.live || {};
             const inBps = live.in_bps || 0;
             const outBps = live.out_bps || 0;
@@ -1005,7 +1082,7 @@
             
             const linkParticles = particles[linkId];
             
-            ctx.save();
+            drawCtx.save();
             if (linkParticles.forward && Array.isArray(linkParticles.forward)) {
                 linkParticles.forward.forEach(particle => {
                 particle.progress += (particle.speed * 0.005);
@@ -1013,17 +1090,16 @@
                 
                 const pos = getPointOnPath(points, particle.progress);
                 
-                ctx.globalAlpha = particle.opacity * 0.3;
-                ctx.fillStyle = '#00ff00';
-                ctx.beginPath();
-                ctx.arc(pos.x, pos.y, particle.size * 2, 0, Math.PI * 2);
-                ctx.fill();
-                
-                ctx.globalAlpha = particle.opacity;
-                ctx.fillStyle = '#40ff40';
-                ctx.beginPath();
-                ctx.arc(pos.x, pos.y, particle.size, 0, Math.PI * 2);
-                ctx.fill();
+                drawCtx.globalAlpha = particle.opacity * 0.3;
+                drawCtx.fillStyle = '#00ff00';
+                drawCtx.beginPath();
+                drawCtx.arc(pos.x, pos.y, particle.size * 2, 0, Math.PI * 2);
+                drawCtx.fill();
+                drawCtx.globalAlpha = particle.opacity;
+                drawCtx.fillStyle = '#40ff40';
+                drawCtx.beginPath();
+                drawCtx.arc(pos.x, pos.y, particle.size, 0, Math.PI * 2);
+                drawCtx.fill();
                 });
             }
             
@@ -1034,20 +1110,19 @@
                 
                 const pos = getPointOnPath(points, 1 - particle.progress);
                 
-                ctx.globalAlpha = particle.opacity * 0.3;
-                ctx.fillStyle = '#0080ff';
-                ctx.beginPath();
-                ctx.arc(pos.x, pos.y, particle.size * 2, 0, Math.PI * 2);
-                ctx.fill();
-                
-                ctx.globalAlpha = particle.opacity;
-                ctx.fillStyle = '#40a0ff';
-                ctx.beginPath();
-                ctx.arc(pos.x, pos.y, particle.size, 0, Math.PI * 2);
-                ctx.fill();
+                drawCtx.globalAlpha = particle.opacity * 0.3;
+                drawCtx.fillStyle = '#0080ff';
+                drawCtx.beginPath();
+                drawCtx.arc(pos.x, pos.y, particle.size * 2, 0, Math.PI * 2);
+                drawCtx.fill();
+                drawCtx.globalAlpha = particle.opacity;
+                drawCtx.fillStyle = '#40a0ff';
+                drawCtx.beginPath();
+                drawCtx.arc(pos.x, pos.y, particle.size, 0, Math.PI * 2);
+                drawCtx.fill();
                 });
             }
-            ctx.restore();
+            drawCtx.restore();
         }
 
         const defaultNodeStyle = mapData.options?.default_node_style || {};
@@ -1105,15 +1180,22 @@
             return WMNG_CONFIG.colors.link_normal || '#28a745';
         }
 
-        // Single RAF loop helper. When reduced-motion is preferred and flow
-        // animation is disabled, the loop renders once then stops (animationId
-        // nulled) so we don't burn continuous animation work. Toggling flow
-        // back on calls this again to restart the loop.
+        // Single RAF loop helper. The loop redraws the overlay every frame
+        // but only redraws the static (main canvas) layer when staticDirty.
+        // When there is no active traffic (hasActiveTraffic === false) the
+        // loop stops entirely to avoid burning a 60fps redraw cycle for a
+        // static map. applyLiveUpdate() restarts the loop when traffic
+        // reappears. When reduced-motion is preferred and flow animation is
+        // disabled, the loop also stops (animationId nulled).
         function startAnimationLoop() {
             function tick() {
                 animTick += 1;
-                renderMap(true);
-                if (flowAnimationEnabled || !reducedMotion) {
+                if (staticDirty) {
+                    renderMap(true);
+                } else {
+                    renderOverlay();
+                }
+                if (hasActiveTraffic && (flowAnimationEnabled || !reducedMotion)) {
                     animationId = requestAnimationFrame(tick);
                 } else {
                     animationId = null;
@@ -1151,14 +1233,17 @@
                 if (flowAnimationEnabled) {
                     btn.classList.remove('btn-secondary');
                     btn.classList.add('btn-primary');
-                    // Restart RAF loop if it was stopped by the reduced-motion gate
-                    if (!animationId) {
-                        startAnimationLoop();
-                    }
                 } else {
                     btn.classList.remove('btn-primary');
                     btn.classList.add('btn-secondary');
                     particles = []; // Clear particles when disabled
+                }
+                // The static layer changes (solid line ↔ no line), so force a
+                // full redraw. Then restart the RAF loop if appropriate.
+                staticDirty = true;
+                renderMap();
+                if (!animationId && (hasActiveTraffic && (flowAnimationEnabled || !reducedMotion))) {
+                    startAnimationLoop();
                 }
             });
 
@@ -1283,7 +1368,16 @@
             // Nodes may have been added/removed by the live update; keep the
             // lookup map in sync before re-rendering.
             rebuildNodeIndex();
+            staticDirty = true;
+            // Compute whether any link has active traffic so the RAF loop
+            // can pause when the map is idle (zero bps on every link).
+            hasActiveTraffic = Array.isArray(mapData.links) &&
+                mapData.links.some(l => (l.live?.in_bps > 0 || l.live?.out_bps > 0));
             renderMap();
+            // Restart the animation loop if traffic appeared while it was paused.
+            if (hasActiveTraffic && !animationId) {
+                startAnimationLoop();
+            }
         }
 
         function updateStatus() {
@@ -1336,7 +1430,9 @@
                 const out = document.createElement('canvas');
                 out.width = canvas.width; out.height = canvas.height;
                 const octx = out.getContext('2d');
+                // Composite the static main canvas then the dynamic overlay.
                 octx.drawImage(canvas, 0, 0);
+                octx.drawImage(overlayCanvas, 0, 0);
                 const a = document.createElement('a');
                 a.href = out.toDataURL('image/png');
                 a.download = `weathermap-${mapId}.png`;
@@ -1384,6 +1480,7 @@
                         mapData = data;
                         rebuildNodeIndex();
                         lastDataUpdate = Date.now();
+                        staticDirty = true;
                         renderMap();
                     }
                 })
@@ -1407,6 +1504,8 @@
                 const container = document.getElementById('map-container');
                 canvas.width = container.clientWidth;
                 canvas.height = container.clientHeight;
+                syncOverlayCanvas();
+                staticDirty = true;
                 renderMap();
             }
         });

--- a/src/Console/Commands/CreateMapCommand.php
+++ b/src/Console/Commands/CreateMapCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Console\Commands;
+
+use Illuminate\Console\Command;
+use LibreNMS\Plugins\WeathermapNG\Services\MapService;
+
+class CreateMapCommand extends Command
+{
+    protected $signature = 'weathermapng:create-map
+        {name : Map name (alpha-numeric, hyphens, underscores)}
+        {--title= : Map title}
+        {--width=800 : Map width in pixels}
+        {--height=600 : Map height in pixels}
+        {--background=#ffffff : Background hex color}
+        {--tags=* : Tags for the map}';
+
+    protected $description = 'Create a new WeathermapNG map';
+
+    public function __construct(
+        private readonly MapService $mapService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+        $title = $this->option('title');
+        $width = (int) $this->option('width');
+        $height = (int) $this->option('height');
+        $background = $this->option('background');
+        $tags = $this->option('tags');
+
+        $validator = \Illuminate\Support\Facades\Validator::make([
+            'name' => $name,
+            'title' => $title,
+            'width' => $width,
+            'height' => $height,
+        ], [
+            'name' => 'required|string|max:255|alpha_dash|regex:/^[a-z0-9_-]+$/i',
+            'title' => 'nullable|string|max:255',
+            'width' => 'nullable|integer|min:100|max:4096',
+            'height' => 'nullable|integer|min:100|max:4096',
+        ]);
+
+        if ($validator->fails()) {
+            foreach ($validator->errors()->all() as $error) {
+                $this->error($error);
+            }
+
+            return self::FAILURE;
+        }
+
+        $options = ['background' => $background];
+        if (! empty($tags)) {
+            $options['tags'] = $tags;
+        }
+
+        $map = $this->mapService->createMap([
+            'name' => $name,
+            'title' => $title ?? $name,
+            'width' => $width,
+            'height' => $height,
+            'options' => $options,
+        ]);
+
+        $this->info("Map created: ID {$map->id}, Name: {$map->name}");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/DiscoverCommand.php
+++ b/src/Console/Commands/DiscoverCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Console\Commands;
+
+use Illuminate\Console\Command;
+use LibreNMS\Plugins\WeathermapNG\Models\Map;
+use LibreNMS\Plugins\WeathermapNG\Services\AutoDiscoveryService;
+
+class DiscoverCommand extends Command
+{
+    protected $signature = 'weathermapng:discover
+        {map_id : The ID of the map to seed with discovered nodes/links}
+        {--os=* : Comma-separated or repeated OS filters (e.g. --os=iosxe --os=ios)}';
+
+    protected $description = 'Auto-discover devices and seed a map (currently disabled)';
+
+    public function __construct(
+        private readonly AutoDiscoveryService $discoveryService,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $mapId = (int) $this->argument('map_id');
+
+        try {
+            $map = Map::findOrFail($mapId);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            $this->error("Map with ID {$mapId} not found.");
+
+            return self::FAILURE;
+        }
+
+        $osFilters = $this->option('os');
+
+        $params = $this->discoveryService->validateDiscoveryParams([
+            'min_degree' => 0,
+            'os' => implode(',', $osFilters),
+        ]);
+
+        $this->warn('Note: Auto-discovery is currently disabled. No nodes or links will be created.');
+        $this->warn('Future versions will use LibreNMS LLDP/CDP data for topology discovery.');
+
+        $result = $this->discoveryService->discoverAndSeedMap($map, $params);
+
+        if (empty($result)) {
+            $this->info('Discovery completed (no results — feature disabled).');
+
+            return self::SUCCESS;
+        }
+
+        $nodesCreated = count($result['nodes'] ?? []);
+        $linksCreated = count($result['links'] ?? []);
+        $this->info("Discovery complete: {$nodesCreated} nodes, {$linksCreated} links added to map {$map->name}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/ExportMapCommand.php
+++ b/src/Console/Commands/ExportMapCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Console\Commands;
+
+use Illuminate\Console\Command;
+use LibreNMS\Plugins\WeathermapNG\Models\Map;
+
+class ExportMapCommand extends Command
+{
+    protected $signature = 'weathermapng:export
+        {map_id : The ID of the map to export}
+        {--output= : Write output to this file path instead of stdout}
+        {--format=json : Output format (json)}';
+
+    protected $description = 'Export a WeathermapNG map as JSON';
+
+    public function handle(): int
+    {
+        $mapId = (int) $this->argument('map_id');
+
+        try {
+            $map = Map::with(['nodes', 'links'])->findOrFail($mapId);
+        } catch (\Illuminate\Database\Eloquent\ModelNotFoundException $e) {
+            $this->error("Map with ID {$mapId} not found.");
+
+            return self::FAILURE;
+        }
+
+        $json = json_encode(
+            $map->toJsonModel(),
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+        );
+
+        $output = $this->option('output');
+
+        if ($output) {
+            $written = file_put_contents($output, $json);
+            if ($written === false) {
+                $this->error("Failed to write to {$output}");
+
+                return self::FAILURE;
+            }
+            $this->info("Exported map {$map->name} (ID {$map->id}) to {$output}");
+
+            return self::SUCCESS;
+        }
+
+        $this->line($json);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/ListMapsCommand.php
+++ b/src/Console/Commands/ListMapsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace LibreNMS\Plugins\WeathermapNG\Console\Commands;
+
+use Illuminate\Console\Command;
+use LibreNMS\Plugins\WeathermapNG\Models\Map;
+
+class ListMapsCommand extends Command
+{
+    protected $signature = 'weathermapng:list-maps
+        {--format=table : Output format (table or json)}';
+
+    protected $description = 'List all WeathermapNG maps';
+
+    public function handle(): int
+    {
+        $maps = Map::with(['nodes', 'links'])->get();
+
+        $format = $this->option('format');
+
+        if ($format === 'json') {
+            $rows = $maps->map(fn ($map) => [
+                'id' => $map->id,
+                'name' => $map->name,
+                'title' => $map->title,
+                'width' => $map->width,
+                'height' => $map->height,
+                'background' => $map->background,
+                'tags' => $map->tags,
+                'nodes' => $map->nodes->count(),
+                'links' => $map->links->count(),
+                'updated_at' => $map->updated_at?->toIso8601String(),
+            ])->toArray();
+
+            $this->line(json_encode($rows, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        $rows = $maps->map(fn ($map) => [
+            $map->id,
+            $map->name,
+            $map->title,
+            $map->nodes->count(),
+            $map->links->count(),
+            $map->updated_at?->diffForHumans() ?? '—',
+        ])->toArray();
+
+        $this->table(
+            ['ID', 'Name', 'Title', 'Nodes', 'Links', 'Updated'],
+            $rows
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Services/LinkService.php
+++ b/src/Services/LinkService.php
@@ -63,18 +63,50 @@ class LinkService
         $this->validatePortDevicePairing($linkData, $srcNode, $dstNode);
     }
 
+    /**
+     * Batch validation variant of validateLinkForMap using pre-fetched maps.
+     * Avoids per-link Node::find() and fetchPort() queries during storeLinks.
+     *
+     * @param \Illuminate\Support\Collection<int, Node> $nodesById  Nodes keyed by id, already filtered to the map.
+     * @param array<int, object|null>                   $portsById  Ports keyed by port_id.
+     */
+    private function validateLinkForMapBatch(Map $map, array $linkData, $nodesById, array $portsById): void
+    {
+        $this->validateLinkData($linkData);
+
+        $srcNode = $nodesById[$linkData['src_node_id']] ?? null;
+        $dstNode = $nodesById[$linkData['dst_node_id']] ?? null;
+
+        $this->validateNodesBelongToMap($map, $srcNode, $dstNode);
+        $this->validatePortDevicePairingBatch($linkData, $srcNode, $dstNode, $portsById);
+    }
+
     public function storeLinks(Map $map, array $linksData): void
     {
         if (empty($linksData) && $map->links()->exists()) {
             throw new \InvalidArgumentException('Cannot replace links with an empty array for an existing map');
         }
 
+        $nodesById = collect($linksData)
+            ->flatMap(fn ($l) => [$l['src_node_id'] ?? null, $l['dst_node_id'] ?? null])
+            ->filter()
+            ->unique()
+            ->pipe(fn ($ids) => Node::whereIn('id', $ids)->where('map_id', $map->id)->get()->keyBy('id'));
+
+        $portsById = $this->batchFetchPorts(
+            collect($linksData)
+                ->flatMap(fn ($l) => [$l['port_id_a'] ?? null, $l['port_id_b'] ?? null])
+                ->filter()
+                ->unique()
+                ->all()
+        );
+
         try {
-            DB::transaction(function () use ($map, $linksData) {
+            DB::transaction(function () use ($map, $linksData, $nodesById, $portsById) {
                 $map->links()->delete();
 
                 foreach ($linksData as $linkData) {
-                    $this->validateLinkForMap($map, $linkData);
+                    $this->validateLinkForMapBatch($map, $linkData, $nodesById, $portsById);
 
                     Link::create([
                         'map_id' => $map->id,
@@ -162,6 +194,61 @@ class LinkService
         }
     }
 
+    /**
+     * Batch variant of validatePortDevicePairing using a pre-fetched port map.
+     *
+     * @param array<int, object|null> $portsById Ports keyed by port_id.
+     */
+    private function validatePortDevicePairingBatch(array $data, ?Node $srcNode, ?Node $dstNode, array $portsById): void
+    {
+        $this->validateSourcePortDeviceBatch($data, $srcNode, $portsById);
+        $this->validateDestinationPortDeviceBatch($data, $dstNode, $portsById);
+    }
+
+    private function validateSourcePortDeviceBatch(array $data, ?Node $srcNode, array $portsById): void
+    {
+        $portId = $data['port_id_a'] ?? null;
+
+        if (!$portId) {
+            return;
+        }
+
+        $this->validatePortBelongsToDeviceBatch($portId, $srcNode, $portsById);
+    }
+
+    private function validateDestinationPortDeviceBatch(array $data, ?Node $dstNode, array $portsById): void
+    {
+        $portId = $data['port_id_b'] ?? null;
+
+        if (!$portId) {
+            return;
+        }
+
+        $this->validatePortBelongsToDeviceBatch($portId, $dstNode, $portsById);
+    }
+
+    /**
+     * Batch variant of validatePortBelongsToDevice using a pre-fetched port map.
+     *
+     * @param array<int, object|null> $portsById Ports keyed by port_id.
+     */
+    private function validatePortBelongsToDeviceBatch(int $portId, ?Node $node, array $portsById): void
+    {
+        if (!$node || !$node->device_id) {
+            return;
+        }
+
+        $port = $portsById[$portId] ?? null;
+
+        if (!$port) {
+            throw new \InvalidArgumentException("Port {$portId} not found");
+        }
+
+        if ($port->device_id != $node->device_id) {
+            throw new \InvalidArgumentException("Port {$portId} does not belong to device {$node->device_id}");
+        }
+    }
+
     private function fetchPort(int $portId): ?object
     {
         try {
@@ -173,6 +260,32 @@ class LinkService
             return DB::table('ports')->where('port_id', $portId)->first();
         } catch (\Exception $e) {
             return null;
+        }
+    }
+
+    /**
+     * Fetch a batch of ports keyed by port_id in a single query.
+     * Mirrors fetchPort()'s class_exists('\App\Models\Port') fallback path.
+     *
+     * @param array<int, int|string> $portIds
+     * @return array<int, object|null>  Ports keyed by port_id.
+     */
+    private function batchFetchPorts(array $portIds): array
+    {
+        $portIds = array_values(array_filter($portIds));
+        if (empty($portIds)) {
+            return [];
+        }
+
+        try {
+            $portClass = '\\App\\Models\\Port';
+            if (class_exists($portClass)) {
+                return $portClass::whereIn('port_id', $portIds)->get()->keyBy('port_id')->all();
+            }
+
+            return DB::table('ports')->whereIn('port_id', $portIds)->get()->keyBy('port_id')->all();
+        } catch (\Exception $e) {
+            return [];
         }
     }
 

--- a/src/Services/NodeDataService.php
+++ b/src/Services/NodeDataService.php
@@ -54,20 +54,20 @@ class NodeDataService
     public function buildNodeData(Map $map): array
     {
         $metricsMap = $this->deviceDataService->getNodeMetricsBatch($map->nodes->all());
-        $links = $map->links;
+        $nodeLinksIndex = $this->buildNodeLinksIndex($map->links);
 
         $nodeData = [];
         foreach ($map->nodes as $node) {
             $nodeData[$node->id] = $this->buildNodeWithMetrics(
                 $node,
                 $metricsMap[$node->id] ?? ['cpu' => null, 'mem' => null],
-                $links
+                $nodeLinksIndex[$node->id] ?? []
             );
         }
         return $nodeData;
     }
 
-    private function buildNodeWithMetrics(Node $node, array $metrics, $links): array
+    private function buildNodeWithMetrics(Node $node, array $metrics, array $links): array
     {
         $status = $this->deviceDataService->getNodeStatus($node);
         $trafficData = $this->aggregateNodeTraffic($node, $links);
@@ -229,7 +229,7 @@ class NodeDataService
         return connection_aborted() || (time() - $startTime) >= $maxSeconds;
     }
 
-    private function aggregateNodeTraffic(Node $node, $links): array
+    private function aggregateNodeTraffic(Node $node, array $links): array
     {
         $demoMode = config('weathermapng.demo_mode', false);
 
@@ -301,7 +301,7 @@ class NodeDataService
         ];
     }
 
-    private function sumPortTraffic(Node $node, $links): array
+    private function sumPortTraffic(Node $node, array $links): array
     {
         $inSum = 0;
         $outSum = 0;
@@ -325,5 +325,19 @@ class NodeDataService
             'sum_bps' => $inSum + $outSum,
             'source' => ($inSum + $outSum) > 0 ? 'ports' : 'none',
         ];
+    }
+
+    /**
+     * Build a nodeId → Link[] index so each node's traffic aggregation
+     * only iterates its own links (O(L) total) instead of all links (O(N×L)).
+     */
+    private function buildNodeLinksIndex($links): array
+    {
+        $index = [];
+        foreach ($links as $link) {
+            $index[$link->src_node_id][] = $link;
+            $index[$link->dst_node_id][] = $link;
+        }
+        return $index;
     }
 }

--- a/src/WeathermapNGProvider.php
+++ b/src/WeathermapNGProvider.php
@@ -6,11 +6,28 @@ use Illuminate\Support\ServiceProvider;
 use LibreNMS\Interfaces\Plugins\Hooks\MenuEntryHook;
 use LibreNMS\Interfaces\Plugins\Hooks\SettingsHook;
 use LibreNMS\Interfaces\Plugins\PluginManagerInterface;
+use LibreNMS\Plugins\WeathermapNG\Console\Commands\CreateMapCommand;
+use LibreNMS\Plugins\WeathermapNG\Console\Commands\DiscoverCommand;
+use LibreNMS\Plugins\WeathermapNG\Console\Commands\ExportMapCommand;
+use LibreNMS\Plugins\WeathermapNG\Console\Commands\ListMapsCommand;
 use LibreNMS\Plugins\WeathermapNG\Hooks\MenuEntry;
 use LibreNMS\Plugins\WeathermapNG\Hooks\Settings;
 
 class WeathermapNGProvider extends ServiceProvider
 {
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        $this->commands([
+            CreateMapCommand::class,
+            ListMapsCommand::class,
+            ExportMapCommand::class,
+            DiscoverCommand::class,
+        ]);
+    }
+
     /**
      * Bootstrap any package services.
      */

--- a/tests/EditorPropertiesTest.php
+++ b/tests/EditorPropertiesTest.php
@@ -49,7 +49,8 @@ class EditorPropertiesTest extends TestCase
         $labelBlock = substr($content, strpos($content, 'label.oninput = function'), 250);
         $this->assertStringContainsString('markUnsaved()', $labelBlock);
 
-        $devBlock = substr($content, strpos($content, 'devSel.onchange = function'), 250);
+        // Device selection via autocomplete now triggers markUnsaved in the select callback
+        $devBlock = substr($content, strpos($content, 'if (devHidden) devHidden.value = device.device_id'), 300);
         $this->assertStringContainsString('markUnsaved()', $devBlock);
     }
 


### PR DESCRIPTION
## Summary

A parallel batch of performance optimizations, CLI commands, and editor improvements — 5 feature branches merged into one PR.

### Added

- **CLI commands for map management**: Four new `lnms` commands — `weathermapng:create-map`, `weathermapng:list-maps`, `weathermapng:export`, `weathermapng:discover`. Registered via Artisan through the plugin's ServiceProvider. Reuses existing `MapService::createMap()` and `Map::toJsonModel()` — no backend refactoring needed. Verified live in Docker: all 4 commands appear in `lnms list` and `lnms weathermapng:list-maps` outputs 6 maps.
- **Editor device autocomplete**: Device selection in the editor now uses a debounced search input with live dropdown results from the existing `/api/devices?q=` endpoint (LIMIT 20, cached 300s). Replaces the full device list `<select>` that loaded every device into the DOM. Also applies to the node properties "Change" device flow. Zero backend changes — the autocomplete API already existed.
- **Editor status-aware node colors**: Editor nodes now reflect device status — green (up), red (down), gray (unknown) — using the `status` field already present in the JSON payload but previously discarded by `loadMapData()`. Down nodes get a red dashed ring.

### Performance

- **Canvas layer separation in embed view**: Static content (background, links, nodes, labels) now renders on the main canvas while dynamic content (particles, dash animations) renders on a separate overlay canvas. The animation loop only redraws the overlay when static content hasn't changed — eliminates 60fps full-canvas redraws.
- **RAF pause on zero traffic**: The animation loop pauses entirely when no link has active traffic, eliminating unnecessary CPU usage. Restarts automatically when traffic appears in a live update.
- **O(N×L)→O(L) node→links index in `NodeDataService`**: `sumPortTraffic()` now uses a pre-built `nodeId → Link[]` index instead of iterating all links per node. For a 200-node, 300-link map: 60,000 iterations → ~600.
- **Batch link validation in `LinkService::storeLinks`**: Pre-fetches all referenced nodes and ports in 2 queries instead of 2L+P per-link queries. Validation does array lookups against the pre-fetched maps.

## Verification

- **311 tests pass** (953 assertions, 1 skipped)
- All 4 CLI commands verified live in Docker container (`lnms list | grep weathermapng`, `lnms weathermapng:list-maps`)
- `php -l` syntax check passes on all modified files
- All 5 branches merge cleanly with no conflicts

## Test plan

- [x] `vendor/bin/phpunit` — 311 tests, 953 assertions, 1 skipped
- [x] `lnms list | grep weathermapng` — 4 commands visible
- [x] `lnms weathermapng:list-maps` — outputs 6 maps in table format
- [ ] Manual: embed view renders with overlay canvas, particles animate on overlay only
- [ ] Manual: editor device autocomplete search works with debounced input
- [ ] Manual: editor nodes show status-based colors (green/red/gray)
