### PR TITLE
feat: embed status icons + alert click-through, AlertService history, config export round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
 All notable changes to WeathermapNG will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- **Embed status-based node visuals**: Down nodes now have a pulsing red outer ring on the overlay canvas (animated via `animTick`). Warning nodes (up but CPU/MEM ≥ threshold) get a yellow dashed ring. Unknown nodes get a gray dashed outline. The `node_warning` color is now admin-configurable via `weathermapng.colors.node_warning`.
+- **Alert badge click-through in embed view**: Alert badges on nodes and links are now clickable. Node alert badges open the LibreNMS device alerts page (`/device/{id}/tab=alerts/`). Link alert badges open the alerts page for the source node's device.
+- **Alert info in embed hover tooltip**: The text tooltip now shows alert count and severity for nodes and links with active alerts.
+- **Alerts in initial page load**: Alert badges now appear immediately on embed page load instead of waiting for the first SSE/poll event.
+- **Alert history queries in `AlertService`**: New `deviceAlertHistory()` and `portAlertHistory()` methods query alerts without the `state != 0` filter, selecting `id`, `timestamp`, `state`, and `severity`, ordered by timestamp DESC. Existing fetch methods also now select `id` and `timestamp` (backward-compatible).
+- **JSON export round-trip improvements**: `toJsonModel()` now includes a `_format: "weathermapng-map-v1"` version stamp. Import form auto-fills map `name` and `title` from the uploaded JSON file. New `Map::createFromJsonData()` static method extracts the import logic for reuse.
+- **Metrics merge fix in embed SSE**: `applyLiveUpdate()` now merges `metrics` (CPU/MEM) from SSE payloads — previously discarded, making the CPU/MEM warning color branch dead code for live-updated nodes.
 - **CLI commands for map management**: Four new `lnms` commands — `weathermapng:create-map`, `weathermapng:list-maps`, `weathermapng:export`, `weathermapng:discover`. Registered via Artisan through the plugin's ServiceProvider. Reuses existing `MapService::createMap()` and `Map::toJsonModel()` — no backend refactoring needed.
 - **Editor device autocomplete**: Device selection in the editor now uses a debounced search input with live dropdown results from the existing `/api/devices?q=` endpoint (LIMIT 20, cached 300s). Replaces the full device list `<select>` that loaded every device into the DOM. Also applies to the node properties "Change" device flow.
 - **Editor status-aware node colors**: Editor nodes now reflect device status — green (up), red (down), gray (unknown) — using the `status` field already present in the JSON payload but previously discarded. Down nodes get a red dashed ring.

--- a/resources/views/embed.blade.php
+++ b/resources/views/embed.blade.php
@@ -359,6 +359,7 @@
                 link_critical: '{{ config('weathermapng.colors.link_critical', '#dc3545') }}',
                 node_up: '{{ config('weathermapng.colors.node_up', '#28a745') }}',
                 node_down: '{{ config('weathermapng.colors.node_down', '#dc3545') }}',
+                node_warning: '{{ config('weathermapng.colors.node_warning', '#ffc107') }}',
                 node_unknown: '{{ config('weathermapng.colors.node_unknown', '#6c757d') }}'
             },
             enable_sse: @json(config('weathermapng.enable_sse') ?? true),
@@ -386,13 +387,46 @@
             mapData = @json($mapData ?? []);
             // Apply initial live data if provided
             const initialLive = @json($liveData ?? []);
-            if (initialLive && initialLive.links && Array.isArray(mapData.links)) {
-                mapData.links.forEach(l => {
-                    const id = l.id ?? l.link_id ?? null;
-                    if (id && initialLive.links[id]) {
-                        l.live = initialLive.links[id];
+            if (initialLive) {
+                if (initialLive.links && Array.isArray(mapData.links)) {
+                    mapData.links.forEach(l => {
+                        const id = l.id ?? l.link_id ?? null;
+                        if (id && initialLive.links[id]) {
+                            l.live = initialLive.links[id];
+                        }
+                    });
+                }
+                // Apply initial node status, metrics, and traffic.
+                if (initialLive.nodes && Array.isArray(mapData.nodes)) {
+                    mapData.nodes.forEach(n => {
+                        const id = n.id ?? n.node_id ?? null;
+                        if (id && initialLive.nodes[id]) {
+                            const ln = initialLive.nodes[id];
+                            n.status = ln.status || n.status;
+                            if (ln.metrics) n.metrics = ln.metrics;
+                            if (ln.traffic) {
+                                n.traffic = ln.traffic;
+                                const sum = Number(ln.traffic.sum_bps || 0);
+                                n.current_value = isFinite(sum) ? sum : null;
+                            }
+                        }
+                    });
+                }
+                // Apply initial alert overlays.
+                if (initialLive.alerts) {
+                    if (initialLive.alerts.nodes && Array.isArray(mapData.nodes)) {
+                        mapData.nodes.forEach(n => {
+                            const id = n.id ?? n.node_id ?? null;
+                            n.alerts = (id && initialLive.alerts.nodes[id]) ? initialLive.alerts.nodes[id] : { count: 0, severity: 'ok' };
+                        });
                     }
-                });
+                    if (initialLive.alerts.links && Array.isArray(mapData.links)) {
+                        mapData.links.forEach(l => {
+                            const id = l.id ?? l.link_id ?? null;
+                            l.alerts = (id && initialLive.alerts.links[id]) ? initialLive.alerts.links[id] : { count: 0, severity: 'ok' };
+                        });
+                    }
+                }
                 lastDataUpdate = Date.now();
             }
         } catch (e) {
@@ -577,7 +611,14 @@
                     drawLinkDynamic(link, overlayCtx);
                 });
             }
-            overlayCtx.restore();
+            // Down-node pulse rings (dynamic, drawn on overlay canvas).
+            if (Array.isArray(mapData.nodes)) {
+                mapData.nodes.forEach(node => {
+                    if ((node.status || 'unknown') === 'down') {
+                        drawNodePulse(node, overlayCtx);
+                    }
+                });
+            }
         }
 
         function initKioskMode() {
@@ -725,6 +766,7 @@
             const nodeType = getNodeType(node);
             const color = getNodeColor(node);
             const radius = 10; // Base radius for hit testing and badges
+            const status = node.status || 'unknown';
 
             ctx.fillStyle = color;
             ctx.strokeStyle = '#000';
@@ -791,6 +833,27 @@
                 ctx.fill();
                 ctx.stroke();
             }
+            // Static status-based rings (drawn on main canvas).
+            // Warning nodes (up but CPU/MEM high): yellow dashed ring.
+            if (isWarningNode(node)) {
+                ctx.beginPath();
+                ctx.arc(x, y, radius + 5, 0, 2 * Math.PI);
+                ctx.strokeStyle = 'rgba(255, 193, 7, 0.7)';
+                ctx.lineWidth = 2;
+                ctx.setLineDash([4, 3]);
+                ctx.stroke();
+                ctx.setLineDash([]);
+            }
+            // Unknown nodes: subtle gray dashed outline.
+            else if (status === 'unknown') {
+                ctx.beginPath();
+                ctx.arc(x, y, radius + 4, 0, 2 * Math.PI);
+                ctx.strokeStyle = 'rgba(108, 117, 125, 0.5)';
+                ctx.lineWidth = 1.5;
+                ctx.setLineDash([2, 2]);
+                ctx.stroke();
+                ctx.setLineDash([]);
+            }
 
             // Node label
             ctx.fillStyle = defaultNodeStyle.label_color || '#000';
@@ -828,6 +891,21 @@
 
             // store geometry for hover
             nodeGeoms.push({ x, y, r: radius, node });
+        }
+
+        // Draw a pulsing red ring around down nodes on the overlay canvas.
+        // Uses animTick for the animation phase so it syncs with the RAF loop.
+        function drawNodePulse(node, octx) {
+            const x = (node.position?.x ?? node.x) || 0;
+            const y = (node.position?.y ?? node.y) || 0;
+            const radius = 10;
+            const phase = reducedMotion ? 0 : animTick * 0.1;
+            const pulseRadius = radius + 4 + 3 * Math.sin(phase);
+            octx.beginPath();
+            octx.arc(x, y, pulseRadius, 0, 2 * Math.PI);
+            octx.strokeStyle = 'rgba(220, 53, 69, ' + (0.4 + 0.3 * Math.sin(phase)) + ')';
+            octx.lineWidth = 3;
+            octx.stroke();
         }
 
         function buildLinkPath(link, x1, y1, x2, y2) {
@@ -1128,17 +1206,24 @@
         const defaultNodeStyle = mapData.options?.default_node_style || {};
         const defaultLinkStyle = mapData.options?.default_link_style || {};
 
+        // Reusable threshold check: returns true if a CPU/MEM value exceeds
+        // the warning threshold (second element of WMNG_CONFIG.thresholds).
+        function warnThreshold(v) {
+            return typeof v === 'number' && v >= ((WMNG_CONFIG.thresholds && WMNG_CONFIG.thresholds[1]) || 80);
+        }
+
+        function isWarningNode(node) {
+            const status = node.status || 'unknown';
+            return status === 'up' && (warnThreshold(node.metrics?.cpu) || warnThreshold(node.metrics?.mem));
+        }
+
         function getNodeColor(node) {
             const colors = WMNG_CONFIG.colors || {};
             if (node?.meta?.color) return node.meta.color;
 
             const status = node.status || 'unknown';
             if (status === 'down') return colors.node_down || '#dc3545';
-            // If up but CPU or MEM high, warn
-            const cpu = node.metrics?.cpu;
-            const mem = node.metrics?.mem;
-            const warn = (v) => typeof v === 'number' && v >= ((WMNG_CONFIG.thresholds && WMNG_CONFIG.thresholds[1]) || 80);
-            if (status === 'up' && (warn(cpu) || warn(mem))) return colors.node_warning || '#ffc107';
+            if (isWarningNode(node)) return colors.node_warning || '#ffc107';
             if (status === 'up') return defaultNodeStyle.color || colors.node_up || '#28a745';
             return defaultNodeStyle.color || colors.node_unknown || '#6c757d';
         }
@@ -1195,7 +1280,10 @@
                 } else {
                     renderOverlay();
                 }
-                if (hasActiveTraffic && (flowAnimationEnabled || !reducedMotion)) {
+                const hasDownNode = Array.isArray(mapData.nodes) &&
+                    mapData.nodes.some(n => (n.status || 'unknown') === 'down');
+                if ((hasActiveTraffic && (flowAnimationEnabled || !reducedMotion)) ||
+                    (hasDownNode && !reducedMotion)) {
                     animationId = requestAnimationFrame(tick);
                 } else {
                     animationId = null;
@@ -1341,6 +1429,7 @@
                     const id = n.id ?? n.node_id ?? null;
                     if (id && live.nodes[id]) {
                         n.status = live.nodes[id].status || n.status;
+                        if (live.nodes[id].metrics) n.metrics = live.nodes[id].metrics;
                         // Attach aggregated traffic and expose a simple value for label
                         if (live.nodes[id].traffic) {
                             n.traffic = live.nodes[id].traffic;
@@ -1374,8 +1463,11 @@
             hasActiveTraffic = Array.isArray(mapData.links) &&
                 mapData.links.some(l => (l.live?.in_bps > 0 || l.live?.out_bps > 0));
             renderMap();
-            // Restart the animation loop if traffic appeared while it was paused.
-            if (hasActiveTraffic && !animationId) {
+            // Restart the animation loop if traffic appeared or a down-node
+            // pulse is needed while it was paused.
+            const hasDownNode = Array.isArray(mapData.nodes) &&
+                mapData.nodes.some(n => (n.status || 'unknown') === 'down');
+            if ((hasActiveTraffic || hasDownNode) && !animationId) {
                 startAnimationLoop();
             }
         }
@@ -1677,7 +1769,10 @@
                   `In: ${humanBits(t.in_bps ?? 0)}<br>` +
                   `Out: ${humanBits(t.out_bps ?? 0)}<br>` +
                   `Total (In + Out): ${humanBits(sum ?? 0)}<br>` +
-                  `<span style="opacity:0.75;">Source: ${src}</span>`;
+                  `<span style="opacity:0.75;">Source: ${src}</span>` +
+                  (n.alerts && n.alerts.count > 0
+                    ? `<br><span style="color:#ffc107;">⚠ ${n.alerts.count} alert${n.alerts.count > 1 ? 's' : ''} (${n.alerts.severity || 'warning'})</span>`
+                    : '');
                 if (n.device_id) newTarget = { type: 'node', id: n.id, data: n };
             } else if (best) {
                 tooltip.style.display = 'block';
@@ -1687,7 +1782,10 @@
                 const bwLine = best.bandwidth ? `<br><span style="opacity:0.75;">Capacity: ${humanBits(best.bandwidth)}</span>` : '';
                 tooltip.innerHTML = `<b>Utilization: ${pctVal}</b><br>` +
                     `<span style="color:#40ff40;">▼</span> In: ${humanBits(best.inBps)}<br>` +
-                    `<span style="color:#40a0ff;">▲</span> Out: ${humanBits(best.outBps)}` + bwLine;
+                    `<span style="color:#40a0ff;">▲</span> Out: ${humanBits(best.outBps)}` + bwLine +
+                    (best.link && best.link.alerts && best.link.alerts.count > 0
+                      ? `<br><span style="color:#ffc107;">⚠ ${best.link.alerts.count} alert${best.link.alerts.count > 1 ? 's' : ''} (${best.link.alerts.severity || 'warning'})</span>`
+                      : '');
                 const link = best.link;
                 if (link && (link.port_id_a || link.port_id_b)) newTarget = { type: 'link', id: link.id, data: link };
             } else {
@@ -1718,7 +1816,39 @@
             const y = e.clientY - rect.top;
             const mx = (x - viewOffsetX) / Math.max(0.0001, viewScale);
             const my = (y - viewOffsetY) / Math.max(0.0001, viewScale);
-            // Node first
+            // Alert badge hit detection (before node/link) — opens device alerts.
+            for (const g of nodeGeoms) {
+                const n = g.node;
+                if (n.alerts && n.alerts.count > 0) {
+                    const bx = g.x + g.r - 3;
+                    const by = g.y - g.r + 3;
+                    if (Math.hypot(mx - bx, my - by) < 10) {
+                        const did = n.device_id || n.deviceId || n.deviceid;
+                        if (did) {
+                            window.open(deviceBaseUrl + '/' + did + '/tab=alerts/', WMNG_CONFIG.linkTarget || '_blank');
+                        }
+                        return;
+                    }
+                }
+            }
+            // Link alert badge hit detection (diamond at midpoint offset).
+            for (const g of linkGeoms) {
+                const link = g.link;
+                if (link && link.alerts && link.alerts.count > 0) {
+                    const mid = getPathMidpoint(g.points);
+                    const bx = mid.x + 10;
+                    const by = mid.y - 10;
+                    if (Math.hypot(mx - bx, my - by) < 12) {
+                        const srcId = link.source ?? link.src ?? link.source_id;
+                        const srcNode = nodeById.get(srcId);
+                        const did = srcNode && (srcNode.device_id || srcNode.deviceId || srcNode.deviceid);
+                        if (did) {
+                            window.open(deviceBaseUrl + '/' + did + '/tab=alerts/', WMNG_CONFIG.linkTarget || '_blank');
+                        }
+                        return;
+                    }
+                }
+            }
             for (const g of nodeGeoms) {
                 if (Math.hypot(mx - g.x, my - g.y) <= g.r + 4) {
                     const n = g.node;

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -850,10 +850,51 @@ $('#createMapForm').on('submit', function(e) {
     });
 });
 
-// ===== File Input Label Update =====
+// ===== File Input Label Update + Auto-fill from JSON =====
 $('#import-file').on('change', function() {
     const fileName = this.files[0]?.name || 'Choose file...';
     $(this).next('.custom-file-label').text(fileName);
+
+    const file = this.files[0];
+    if (!file) {
+        return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = function(e) {
+        try {
+            const data = JSON.parse(e.target.result);
+            let filled = false;
+
+            const nameInput = document.getElementById('import-name');
+            if (nameInput && typeof data.name === 'string' && data.name.trim() !== '') {
+                nameInput.value = data.name.trim();
+                filled = true;
+            }
+
+            const titleInput = document.getElementById('import-title');
+            if (titleInput && typeof data.title === 'string' && data.title.trim() !== '') {
+                titleInput.value = data.title.trim();
+                filled = true;
+            }
+
+            if (filled) {
+                // Show a transient "Auto-filled from file" hint on the name field
+                let hint = document.getElementById('import-autofill-hint');
+                if (!hint) {
+                    hint = document.createElement('small');
+                    hint.id = 'import-autofill-hint';
+                    hint.className = 'form-text text-info';
+                    nameInput.parentNode.appendChild(hint);
+                }
+                hint.textContent = 'Auto-filled from file — edit if needed';
+            }
+        } catch (err) {
+            // Not valid JSON or unexpected shape — leave fields empty for manual entry
+            console.warn('Could not pre-fill import form from file:', err);
+        }
+    };
+    reader.readAsText(file);
 });
 
 // ===== Import Map Form =====

--- a/src/Http/Controllers/RenderController.php
+++ b/src/Http/Controllers/RenderController.php
@@ -54,6 +54,7 @@ class RenderController
         $liveData = [
             'links' => $this->nodeDataService->buildLinkData($map),
             'nodes' => $this->nodeDataService->buildNodeData($map),
+            'alerts' => $this->nodeDataService->buildAlertData($map),
         ];
 
         $demoMode = config('weathermapng.demo_mode', false);

--- a/src/Models/Map.php
+++ b/src/Models/Map.php
@@ -3,6 +3,8 @@
 namespace LibreNMS\Plugins\WeathermapNG\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class Map extends Model
 {
@@ -72,6 +74,7 @@ class Map extends Model
         Link::preloadPortNames($portIds);
 
         return [
+            '_format' => 'weathermapng-map-v1',
             'id' => $this->id,
             'name' => $this->name,
             'title' => $this->title,
@@ -102,5 +105,103 @@ class Map extends Model
                 'bandwidth_formatted' => $l->bandwidth_formatted,
             ])->toArray(),
         ];
+    }
+
+    /**
+     * Create a new Map (with nodes and links) from decoded JSON export data.
+     *
+     * The caller supplies the `name` and `title` because the `name` column has
+     * a unique constraint — the user must choose one rather than inheriting it
+     * from the file. Width/height/background are read from either the
+     * top-level keys (server export shape) or nested under `options`
+     * (client export shape) and merged into the stored options.
+     *
+     * Returns the persisted Map model. Runs in a DB transaction so a bad
+     * node/link reference rolls back the whole map.
+     */
+    public static function createFromJsonData(array $data, string $name, ?string $title = null): Map
+    {
+        return DB::transaction(function () use ($data, $name, $title) {
+            $options = is_array($data['options'] ?? null) ? $data['options'] : [];
+
+            // Merge top-level width/height/background (server export shape) into
+            // options so the stored options are self-consistent regardless of
+            // whether the file came from toJsonModel() or the editor's exportJson().
+            foreach (['width', 'height', 'background'] as $key) {
+                if (array_key_exists($key, $data) && !array_key_exists($key, $options)) {
+                    $options[$key] = $data[$key];
+                }
+            }
+            $options['width'] = $options['width'] ?? 800;
+            $options['height'] = $options['height'] ?? 600;
+            $options['background'] = $options['background'] ?? '#ffffff';
+
+            $map = Map::create([
+                'name' => $name,
+                'title' => $title ?? $name,
+                'options' => $options,
+            ]);
+
+            $nodeIdMap = self::createNodesFromData($map, $data['nodes'] ?? []);
+            self::createLinksFromData($map, $data['links'] ?? [], $nodeIdMap);
+
+            return $map;
+        });
+    }
+
+    private static function createNodesFromData(Map $map, array $nodesData): array
+    {
+        $nodeIdMap = [];
+
+        foreach ($nodesData as $index => $nodeData) {
+            $node = Node::create([
+                'map_id' => $map->id,
+                'label' => $nodeData['label'] ?? 'Node',
+                'x' => isset($nodeData['x']) && is_numeric($nodeData['x']) ? (float) $nodeData['x'] : 0,
+                'y' => isset($nodeData['y']) && is_numeric($nodeData['y']) ? (float) $nodeData['y'] : 0,
+                'device_id' => isset($nodeData['device_id']) && is_numeric($nodeData['device_id']) ? (int) $nodeData['device_id'] : null,
+                'meta' => is_array($nodeData['meta'] ?? null) ? $nodeData['meta'] : [],
+            ]);
+
+            $clientKey = $nodeData['id'] ?? $nodeData['node_id'] ?? $nodeData['_id'] ?? (string) $index;
+            $nodeIdMap[$clientKey] = $node->id;
+        }
+
+        return $nodeIdMap;
+    }
+
+    private static function createLinksFromData(Map $map, array $linksData, array $nodeIdMap): void
+    {
+        foreach ($linksData as $linkData) {
+            $sourceId = self::resolveNodeIdFromMap($linkData['src_node_id'] ?? $linkData['source'] ?? $linkData['src'] ?? null, $nodeIdMap);
+            $targetId = self::resolveNodeIdFromMap($linkData['dst_node_id'] ?? $linkData['target'] ?? $linkData['dst'] ?? null, $nodeIdMap);
+            if (!$sourceId || !$targetId) {
+                Log::warning('WeathermapNG: dropped link with unresolvable node reference', [
+                    'map_id' => $map->id,
+                    'src' => $linkData['src_node_id'] ?? $linkData['source'] ?? $linkData['src'] ?? null,
+                    'dst' => $linkData['dst_node_id'] ?? $linkData['target'] ?? $linkData['dst'] ?? null,
+                ]);
+                continue;
+            }
+
+            Link::create([
+                'map_id' => $map->id,
+                'src_node_id' => $sourceId,
+                'dst_node_id' => $targetId,
+                'port_id_a' => isset($linkData['port_id_a']) && is_numeric($linkData['port_id_a']) ? (int) $linkData['port_id_a'] : (isset($linkData['port_a']) && is_numeric($linkData['port_a']) ? (int) $linkData['port_a'] : null),
+                'port_id_b' => isset($linkData['port_id_b']) && is_numeric($linkData['port_id_b']) ? (int) $linkData['port_id_b'] : (isset($linkData['port_b']) && is_numeric($linkData['port_b']) ? (int) $linkData['port_b'] : null),
+                'bandwidth_bps' => isset($linkData['bandwidth_bps']) && is_numeric($linkData['bandwidth_bps']) ? (int) $linkData['bandwidth_bps'] : (isset($linkData['bandwidth']) && is_numeric($linkData['bandwidth']) ? (int) $linkData['bandwidth'] : null),
+                'style' => $linkData['style'] ?? [],
+            ]);
+        }
+    }
+
+    private static function resolveNodeIdFromMap($clientId, array $nodeIdMap): ?int
+    {
+        if ($clientId === null) {
+            return null;
+        }
+
+        return $nodeIdMap[$clientId] ?? null;
     }
 }

--- a/src/Services/AlertService.php
+++ b/src/Services/AlertService.php
@@ -33,6 +33,59 @@ class AlertService
         return $this->buildAlertsByPort($alerts, $portIds);
     }
 
+    /**
+     * Fetch recent alert history for the given devices (all states, newest first).
+     *
+     * @param  array<int>  $deviceIds
+     * @param  int  $limit  Maximum number of rows to return.
+     * @return array<int, array{id: int, device_id: int, state: int, severity: mixed, timestamp: mixed}> Alert rows ordered by timestamp DESC.
+     */
+    public function deviceAlertHistory(array $deviceIds, int $limit = 10): array
+    {
+        if (empty($deviceIds)) {
+            return [];
+        }
+
+        try {
+            return DB::table('alerts')
+                ->select('id', 'device_id', 'state', 'severity', 'timestamp')
+                ->whereIn('device_id', $deviceIds)
+                ->orderBy('timestamp', 'desc')
+                ->limit($limit)
+                ->get()
+                ->toArray();
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+
+    /**
+     * Fetch recent alert history for the given ports (all states, newest first).
+     *
+     * @param  array<int>  $portIds
+     * @param  int  $limit  Maximum number of rows to return.
+     * @return array<int, array{id: int, port_id: int, state: int, severity: mixed, timestamp: mixed}> Alert rows ordered by timestamp DESC.
+     */
+    public function portAlertHistory(array $portIds, int $limit = 10): array
+    {
+        if (empty($portIds)) {
+            return [];
+        }
+
+        try {
+            return DB::table('alerts')
+                ->select('id', 'entity_id as port_id', 'state', 'severity', 'timestamp')
+                ->where('entity_type', 'port')
+                ->whereIn('entity_id', $portIds)
+                ->orderBy('timestamp', 'desc')
+                ->limit($limit)
+                ->get()
+                ->toArray();
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+
     private function fetchDeviceAlerts(array $deviceIds): array
     {
         $alerts = $this->fetchDeviceAlertsFromTable($deviceIds);
@@ -48,7 +101,7 @@ class AlertService
     {
         try {
             return DB::table('alerts')
-                ->select('device_id', 'state', 'severity')
+                ->select('id', 'device_id', 'state', 'severity', 'timestamp')
                 ->whereIn('device_id', $deviceIds)
                 ->where('state', '!=', 0)
                 ->get()
@@ -62,7 +115,7 @@ class AlertService
     {
         try {
             return DB::table('alerts')
-                ->select('entity_id as device_id', 'state', 'severity')
+                ->select('id', 'entity_id as device_id', 'state', 'severity', 'timestamp')
                 ->where('entity_type', 'device')
                 ->whereIn('entity_id', $deviceIds)
                 ->where('state', '!=', 0)
@@ -112,7 +165,7 @@ class AlertService
     {
         try {
             return DB::table('alerts')
-                ->select('entity_id as port_id', 'state', 'severity')
+                ->select('id', 'entity_id as port_id', 'state', 'severity', 'timestamp')
                 ->where('entity_type', 'port')
                 ->whereIn('entity_id', $portIds)
                 ->where('state', '!=', 0)

--- a/tests/AlertServiceTest.php
+++ b/tests/AlertServiceTest.php
@@ -13,6 +13,13 @@ class AlertServiceTest extends TestCase
     {
         parent::setUp();
         $this->service = new AlertService();
+        \Illuminate\Support\Facades\Facade::clearResolvedInstance('db');
+    }
+
+    protected function tearDown(): void
+    {
+        \Illuminate\Support\Facades\Facade::clearResolvedInstance('db');
+        parent::tearDown();
     }
 
     // --- normalizeSeverity tests (private, tested via reflection) ---
@@ -232,5 +239,248 @@ class AlertServiceTest extends TestCase
 
         $this->assertEquals(2, $result[10]['count']);
         $this->assertEquals('critical', $result[10]['severity']);
+    }
+
+    // --- deviceAlertHistory / portAlertHistory tests ---
+
+    /**
+     * Register a fake DB facade accessor in the container so the service's
+     * DB::table(...) chain returns canned rows. Returns the fake builder so
+     * individual tests can prime it.
+     */
+    private function &fakeDb(): object
+    {
+        $app = \Illuminate\Support\Facades\Facade::getFacadeApplication();
+
+        $builder = new class {
+            private $rows = [];
+            public array $selectedColumns = [];
+            public array $wheres = [];
+            public ?string $orderBy = null;
+            public ?int $limit = null;
+            public string $table = '';
+
+            public function setRows(array $rows): void { $this->rows = $rows; }
+            public function select(...$cols): static { $this->selectedColumns = array_merge($this->selectedColumns, $cols); return $this; }
+            public function where($col, $op = null, $val = null): static { $this->wheres[] = [$col, $op, $val]; return $this; }
+            public function whereIn($col, $vals): static { $this->wheres[] = [$col, 'in', $vals]; return $this; }
+            public function whereNotIn($col, $vals): static { return $this; }
+            public function orderBy($col, $dir = 'asc'): static { $this->orderBy = $col . ':' . $dir; return $this; }
+            public function limit($n): static { $this->limit = $n; return $this; }
+            public function get()
+            {
+                $rows = $this->rows;
+                if ($this->orderBy === 'timestamp:desc') {
+                    usort($rows, fn($a, $b) => $b['timestamp'] <=> $a['timestamp']);
+                }
+                if ($this->limit !== null) {
+                    $rows = array_slice($rows, 0, $this->limit);
+                }
+                return collect($rows);
+            }
+        };
+
+        $fakeConnection = new class($builder) {
+            private $builder;
+            public function __construct($b) { $this->builder = $b; }
+            public function table($table)
+            {
+                $this->builder->table = $table;
+                return $this->builder;
+            }
+        };
+
+        $app->instance('db', $fakeConnection);
+        \Illuminate\Support\Facades\Facade::clearResolvedInstance('db');
+
+        return $builder;
+    }
+
+    /**
+     * Force the DB facade to throw on table() so we exercise the catch path.
+     */
+    private function breakDb(): void
+    {
+        $app = \Illuminate\Support\Facades\Facade::getFacadeApplication();
+        $app->instance('db', new class {
+            public function table($t) { throw new \RuntimeException('db down'); }
+        });
+        \Illuminate\Support\Facades\Facade::clearResolvedInstance('db');
+    }
+
+    public function test_device_alert_history_returns_empty_for_empty_input(): void
+    {
+        $this->assertEmpty($this->service->deviceAlertHistory([]));
+    }
+
+    public function test_device_alert_history_includes_all_states(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 1, 'device_id' => 5, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01'],
+            ['id' => 2, 'device_id' => 5, 'state' => 2, 'severity' => 'critical', 'timestamp' => '2026-02-01'],
+            ['id' => 3, 'device_id' => 5, 'state' => 1, 'severity' => 'warning', 'timestamp' => '2026-03-01'],
+        ]);
+
+        $result = $this->service->deviceAlertHistory([5]);
+
+        $states = array_column($result, 'state');
+        $this->assertContains(0, $states, 'resolved alerts (state 0) must be included');
+        $this->assertContains(2, $states, 'acknowledged alerts (state 2) must be included');
+        $this->assertContains(1, $states, 'active alerts (state 1) must be included');
+    }
+
+    public function test_device_alert_history_ordered_by_timestamp_desc(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 1, 'device_id' => 5, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01 00:00:00'],
+            ['id' => 3, 'device_id' => 5, 'state' => 1, 'severity' => 'warning', 'timestamp' => '2026-03-01 00:00:00'],
+            ['id' => 2, 'device_id' => 5, 'state' => 2, 'severity' => 'critical', 'timestamp' => '2026-02-01 00:00:00'],
+        ]);
+
+        $result = $this->service->deviceAlertHistory([5]);
+
+        $ids = array_column($result, 'id');
+        $this->assertEquals([3, 2, 1], $ids, 'results must be ordered by timestamp DESC');
+    }
+
+    public function test_device_alert_history_respects_limit(): void
+    {
+        $builder = $this->fakeDb();
+        $rows = [];
+        for ($i = 0; $i < 15; $i++) {
+            $rows[] = ['id' => $i + 1, 'device_id' => 5, 'state' => 1, 'severity' => 'warning', 'timestamp' => sprintf('2026-01-%02d', $i + 1)];
+        }
+        $builder->setRows($rows);
+
+        $result = $this->service->deviceAlertHistory([5], 5);
+
+        $this->assertCount(5, $result);
+        $this->assertEquals(5, $builder->limit, 'limit must be forwarded to the query');
+    }
+
+    public function test_device_alert_history_selects_required_columns(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 1, 'device_id' => 5, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01'],
+        ]);
+
+        $this->service->deviceAlertHistory([5]);
+
+        $this->assertEquals(['id', 'device_id', 'state', 'severity', 'timestamp'], $builder->selectedColumns);
+    }
+
+    public function test_device_alert_history_no_state_filter(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 1, 'device_id' => 5, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01'],
+        ]);
+
+        $this->service->deviceAlertHistory([5]);
+
+        $this->assertNotEmpty($builder->wheres, 'query must contain where clauses (device filter)');
+        foreach ($builder->wheres as $where) {
+            $this->assertNotEquals('state', $where[0], 'history query must NOT filter by state');
+        }
+    }
+
+    public function test_device_alert_history_returns_empty_on_failure(): void
+    {
+        $this->breakDb();
+        $this->assertSame([], $this->service->deviceAlertHistory([5]));
+    }
+
+    public function test_port_alert_history_returns_empty_for_empty_input(): void
+    {
+        $this->assertEmpty($this->service->portAlertHistory([]));
+    }
+
+    public function test_port_alert_history_includes_all_states(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 10, 'port_id' => 100, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01'],
+            ['id' => 11, 'port_id' => 100, 'state' => 2, 'severity' => 'critical', 'timestamp' => '2026-02-01'],
+            ['id' => 12, 'port_id' => 100, 'state' => 1, 'severity' => 'warning', 'timestamp' => '2026-03-01'],
+        ]);
+
+        $result = $this->service->portAlertHistory([100]);
+
+        $states = array_column($result, 'state');
+        $this->assertContains(0, $states, 'resolved alerts (state 0) must be included');
+        $this->assertContains(2, $states, 'acknowledged alerts (state 2) must be included');
+        $this->assertContains(1, $states, 'active alerts (state 1) must be included');
+    }
+
+    public function test_port_alert_history_ordered_by_timestamp_desc(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 10, 'port_id' => 100, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01 00:00:00'],
+            ['id' => 12, 'port_id' => 100, 'state' => 1, 'severity' => 'warning', 'timestamp' => '2026-03-01 00:00:00'],
+            ['id' => 11, 'port_id' => 100, 'state' => 2, 'severity' => 'critical', 'timestamp' => '2026-02-01 00:00:00'],
+        ]);
+
+        $result = $this->service->portAlertHistory([100]);
+
+        $ids = array_column($result, 'id');
+        $this->assertEquals([12, 11, 10], $ids, 'results must be ordered by timestamp DESC');
+    }
+
+    public function test_port_alert_history_respects_limit(): void
+    {
+        $builder = $this->fakeDb();
+        $rows = [];
+        for ($i = 0; $i < 15; $i++) {
+            $rows[] = ['id' => $i + 1, 'port_id' => 100, 'state' => 1, 'severity' => 'warning', 'timestamp' => sprintf('2026-01-%02d', $i + 1)];
+        }
+        $builder->setRows($rows);
+
+        $result = $this->service->portAlertHistory([100], 5);
+
+        $this->assertCount(5, $result);
+        $this->assertEquals(5, $builder->limit, 'limit must be forwarded to the query');
+    }
+
+    public function test_port_alert_history_selects_entity_id_as_port_id(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 10, 'port_id' => 100, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01'],
+        ]);
+
+        $this->service->portAlertHistory([100]);
+
+        $this->assertEquals(['id', 'entity_id as port_id', 'state', 'severity', 'timestamp'], $builder->selectedColumns);
+        $hasEntityType = false;
+        foreach ($builder->wheres as $where) {
+            if ($where[0] === 'entity_type' && $where[1] === 'port') {
+                $hasEntityType = true;
+            }
+        }
+        $this->assertTrue($hasEntityType, 'port history must filter entity_type = port');
+    }
+
+    public function test_port_alert_history_no_state_filter(): void
+    {
+        $builder = $this->fakeDb();
+        $builder->setRows([
+            ['id' => 10, 'port_id' => 100, 'state' => 0, 'severity' => 'ok', 'timestamp' => '2026-01-01'],
+        ]);
+
+        $this->service->portAlertHistory([100]);
+        $this->assertNotEmpty($builder->wheres, 'query must contain where clauses (port filter)');
+        foreach ($builder->wheres as $where) {
+            $this->assertNotEquals('state', $where[0], 'port history query must NOT filter by state');
+        }
+    }
+
+    public function test_port_alert_history_returns_empty_on_failure(): void
+    {
+        $this->breakDb();
+        $this->assertSame([], $this->service->portAlertHistory([100]));
     }
 }


### PR DESCRIPTION
## Summary

Batch 2 of parallel work: embed view status/alerts features, AlertService alert history, and config export round-trip fixes.

### Added

- **Embed status-based node visuals**: Down nodes now have a pulsing red outer ring on the overlay canvas (animated via `animTick`). Warning nodes (up but CPU/MEM ≥ threshold) get a yellow dashed ring. Unknown nodes get a gray dashed outline. The `node_warning` color is now admin-configurable via `weathermapng.colors.node_warning`.
- **Alert badge click-through in embed view**: Alert badges on nodes and links are now clickable. Node alert badges open the LibreNMS device alerts page (`/device/{id}/tab=alerts/`). Link alert badges open the alerts page for the source node's device. Badge hit detection takes priority over node/link clicks.
- **Alert info in embed hover tooltip**: The text tooltip now shows alert count and severity for nodes and links with active alerts.
- **Alerts in initial page load**: Alert badges now appear immediately on embed page load instead of waiting for the first SSE/poll event. `RenderController::embed()` now includes `alerts` in the initial `$liveData`.
- **Alert history queries in `AlertService`**: New `deviceAlertHistory()` and `portAlertHistory()` methods query alerts without the `state != 0` filter, selecting `id`, `timestamp`, `state`, and `severity`, ordered by timestamp DESC. Existing fetch methods also now select `id` and `timestamp` (backward-compatible).
- **JSON export round-trip improvements**: `toJsonModel()` now includes a `_format: "weathermapng-map-v1"` version stamp. Import form auto-fills map `name` and `title` from the uploaded JSON file. New `Map::createFromJsonData()` static method extracts the import logic for reuse.

### Fixed

- **Metrics merge fix in embed SSE**: `applyLiveUpdate()` now merges `metrics` (CPU/MEM) from SSE payloads — previously discarded, making the CPU/MEM warning color branch dead code for live-updated nodes.

## Verification

- **325 tests pass** (977 assertions, 1 skipped) — up from 311/953 (14 new AlertServiceTest tests)
- All 3 branches merge cleanly with no conflicts
- `php -l` syntax check passes on all modified files

## Test plan

- [x] `vendor/bin/phpunit` — 325 tests, 977 assertions, 1 skipped
- [x] All 3 branches merge cleanly
- [ ] Manual: embed view shows pulsing red ring for down nodes, yellow dashed for warning
- [ ] Manual: alert badges clickable → opens device alerts page
- [ ] Manual: alert badges appear on initial page load
- [ ] Manual: import form auto-fills name/title from JSON file
