### PR TITLE
Editor bulk operations — multi-select, rubber-band marquee, bulk delete

### DIFF
--- a/resources/js/editor-canvas.js
+++ b/resources/js/editor-canvas.js
@@ -150,14 +150,42 @@ function handleMouseDown(event) {
     }
 
     if (node) {
-        S.selectedNode = node;
+        // Multi-select: shift/ctrl-click toggles membership in the set; a
+        // plain click in selection mode keeps the set (anchoring drag), a
+        // plain click otherwise resets to a single selection.
+        if (event.shiftKey || event.ctrlKey) {
+            const i = S.selectedNodes.indexOf(node);
+            if (i >= 0) {
+                S.selectedNodes.splice(i, 1);
+                if (S.selectedNode === node) {
+                    S.selectedNode = null;
+                }
+            } else {
+                S.selectedNodes.push(node);
+                S.selectedNode = node;
+            }
+        } else if (S.selectionMode) {
+            if (S.selectedNodes.indexOf(node) < 0) {
+                S.selectedNodes.push(node);
+            }
+            S.selectedNode = node;
+        } else {
+            S.selectedNodes = [node];
+            S.selectedNode = node;
+        }
         S.isDragging = true;
         S.dragOffset = { x: x - node.x, y: y - node.y };
-        saveState(); // Save for undo before dragging
-        populateNodeProperties(node);
+        saveState(); // Save for undo
+        populateNodeProperties(S.selectedNode);
         updateToolbarState();
         renderNodesList();
+    } else if (S.selectionMode) {
+        // Selection mode on empty click starts a rubber-band marquee instead
+        // of clearing the selection.
+        S.marquee = { startX: x, startY: y, x: x, y: y };
+        S.isDragging = false;
     } else {
+        S.selectedNodes = [];
         S.selectedNode = null;
         populateNodeProperties(null);
         updateToolbarState();
@@ -175,6 +203,15 @@ function handleMouseMove(event) {
         const scaleY = S.canvas.height / rect.height;
         S.viewOffsetX = S.panStart.offsetX + (event.clientX - S.panStart.clientX) * scaleX;
         S.viewOffsetY = S.panStart.offsetY + (event.clientY - S.panStart.clientY) * scaleY;
+        renderEditor();
+        return;
+    }
+
+    // Rubber-band marquee: track the drag rectangle live.
+    if (S.selectionMode && S.marquee && !S.isDragging) {
+        const pt = getCanvasPoint(event);
+        S.marquee.x = pt.x;
+        S.marquee.y = pt.y;
         renderEditor();
         return;
     }
@@ -213,7 +250,30 @@ function toggleSnapToGrid() {
     renderEditor();
 }
 
-function handleMouseUp() {
+function handleMouseUp(event) {
+    // Finalize a rubber-band marquee: select all nodes inside the rect.
+    if (S.selectionMode && S.marquee) {
+        const m = S.marquee;
+        // Capture the release position as the final corner (in case the
+        // pointer moved after the last mousemove or released without one).
+        const up = getCanvasPoint(event);
+        const left = Math.min(m.startX, up.x);
+        const right = Math.max(m.startX, up.x);
+        const top = Math.min(m.startY, up.y);
+        const bottom = Math.max(m.startY, up.y);
+        S.selectedNodes = S.nodes.filter(n =>
+            n.x >= left && n.x <= right && n.y >= top && n.y <= bottom
+        );
+        if (S.selectedNodes.length > 0) {
+            S.selectedNode = S.selectedNodes[0];
+        }
+        S.marquee = null;
+        populateNodeProperties(S.selectedNode || null);
+        updateToolbarState();
+        renderNodesList();
+        renderEditor();
+        return;
+    }
     S.isDragging = false;
     if (S.isPanning) {
         S.isPanning = false;
@@ -251,7 +311,7 @@ function drawNode(node) {
     // Color based on state: link start (orange), selected (blue), normal (default or green)
     if (S.linkMode && S.linkStart === node) {
         ctx.fillStyle = '#fd7e14'; // Orange for link start
-    } else if (node === S.selectedNode) {
+    } else if (S.selectedNodes.indexOf(node) >= 0 || node === S.selectedNode) {
         ctx.fillStyle = '#0d6efd'; // Blue for selected
     } else {
         ctx.fillStyle = node.status ? getNodeColor(node) : (defaultNodeStyle.color || '#28a745');
@@ -361,6 +421,24 @@ function renderEditor() {
 
     S.links.forEach(drawLink);
     S.nodes.forEach(drawNode);
+
+    // Rubber-band marquee overlay (in transformed canvas coords).
+    if (S.selectionMode && S.marquee) {
+        const m = S.marquee;
+        const rLeft = Math.min(m.startX, m.x);
+        const rTop = Math.min(m.startY, m.y);
+        const rW = Math.abs(m.x - m.startX);
+        const rH = Math.abs(m.y - m.startY);
+        ctx.save();
+        ctx.fillStyle = 'rgba(13, 110, 253, 0.15)';
+        ctx.fillRect(rLeft, rTop, rW, rH);
+        ctx.strokeStyle = '#0d6efd';
+        ctx.lineWidth = 1 / S.viewScale;
+        ctx.setLineDash([4 / S.viewScale, 4 / S.viewScale]);
+        ctx.strokeRect(rLeft, rTop, rW, rH);
+        ctx.setLineDash([]);
+        ctx.restore();
+    }
 
     ctx.restore();
 

--- a/resources/js/editor-nodes.js
+++ b/resources/js/editor-nodes.js
@@ -247,7 +247,7 @@ function renderNodesList() {
     }
 
     S.nodes.forEach((node, idx) => {
-        const isSelected = node === S.selectedNode;
+        const isSelected = S.selectedNodes.indexOf(node) >= 0;
         const row = document.createElement('div');
         row.className = 'd-flex align-items-center justify-content-between py-1 node-list-item' + (isSelected ? ' selected' : '');
         row.addEventListener('click', () => selectNodeByIndex(idx));
@@ -274,9 +274,21 @@ function renderNodesList() {
     });
 }
 
-function selectNodeByIndex(idx) {
+function selectNodeByIndex(idx, additive) {
     if (idx >= 0 && idx < S.nodes.length) {
-        S.selectedNode = S.nodes[idx];
+        const node = S.nodes[idx];
+        if (additive) {
+            const i = S.selectedNodes.indexOf(node);
+            if (i >= 0) {
+                S.selectedNodes.splice(i, 1);
+            } else {
+                S.selectedNodes.push(node);
+            }
+            S.selectedNode = S.selectedNodes[S.selectedNodes.length - 1] || null;
+        } else {
+            S.selectedNodes = [node];
+            S.selectedNode = node;
+        }
         populateNodeProperties(S.selectedNode);
         updateToolbarState();
         renderEditor();

--- a/resources/js/editor-state.js
+++ b/resources/js/editor-state.js
@@ -31,6 +31,10 @@ window.WMNG.EditorState = {
     nodes: [],
     links: [],
     selectedNode: null,
+    // Multi-select set (additive via shift/ctrl-click or rubber-band marquee).
+    // `selectedNode` stays the drag/anchor reference; this set drives bulk ops
+    // and render highlighting.
+    selectedNodes: [],
     mapDataLoaded: false,
     mapDataLoadFailed: false,
     devicesCache: [],
@@ -42,6 +46,9 @@ window.WMNG.EditorState = {
     dragOffset: { x: 0, y: 0 },
     linkMode: false,
     linkStart: null,
+    // Rubber-band marquee selection (selectionMode, active marquee rect).
+    selectionMode: false,
+    marquee: null,
 
     // ---- Zoom / pan ----
     viewScale: 1,

--- a/resources/js/editor-ui.js
+++ b/resources/js/editor-ui.js
@@ -259,15 +259,21 @@ function handleKeyDown(event) {
         return;
     }
 
-    // Escape: Deselect / Cancel link mode
+    // Escape: Deselect / Cancel link mode / exit multi-select
     if (key === 'escape') {
         if (S.linkMode) {
             toggleLinkMode();
         }
-        if (S.selectedNode) {
+        if (S.selectionMode) {
+            toggleSelectionMode();
+        }
+        if (S.selectedNode || S.selectedNodes.length) {
+            S.selectedNodes = [];
             S.selectedNode = null;
             populateNodeProperties(null);
             renderEditor();
+            renderNodesList();
+            updateToolbarState();
         }
         return;
     }
@@ -350,6 +356,7 @@ function undo() {
     const previousState = JSON.parse(S.undoStack.pop());
     S.nodes = previousState.nodes;
     S.links = previousState.links;
+    S.selectedNodes = [];
     S.selectedNode = null;
     populateNodeProperties(null);
     renderEditor();
@@ -373,6 +380,7 @@ function redo() {
     const redoState = JSON.parse(S.redoStack.pop());
     S.nodes = redoState.nodes;
     S.links = redoState.links;
+    S.selectedNodes = [];
     S.selectedNode = null;
     populateNodeProperties(null);
     renderEditor();
@@ -891,10 +899,105 @@ function markSaved() {
 function updateToolbarState() {
     const duplicateBtn = document.getElementById('duplicate-btn');
     const deleteBtn = document.getElementById('delete-node-btn');
+    const bulkDeleteBtn = document.getElementById('bulk-delete-btn');
     const hasSelection = S.selectedNode !== null;
 
     if (duplicateBtn) duplicateBtn.disabled = !hasSelection;
     if (deleteBtn) deleteBtn.disabled = !hasSelection;
+    if (bulkDeleteBtn) bulkDeleteBtn.disabled = S.selectedNodes.length === 0;
+}
+
+// Toggle rubber-band / multi-select mode. In this mode plain canvas clicks
+// add to the selection, empty-click drag draws a marquee, and
+// shift/ctrl-click toggles membership.
+function toggleSelectionMode() {
+    S.selectionMode = !S.selectionMode;
+    if (!S.selectionMode) {
+        S.marquee = null;
+    }
+    const btn = document.getElementById('select-mode-btn');
+    if (btn) {
+        btn.classList.toggle('active', S.selectionMode);
+        btn.title = S.selectionMode ? 'Multi-select (ON) — drag to marquee' : 'Multi-select';
+    }
+    const canvasEl = document.getElementById('map-canvas');
+    if (canvasEl) {
+        canvasEl.style.cursor = S.selectionMode ? 'crosshair' : 'default';
+    }
+    renderEditor();
+}
+
+// Bulk-delete the current multi-selection. Mirrors deleteSelectedNode:
+// undo snapshot, then per-node DELETE when saved (DB cascades attached links)
+// or local splice otherwise. Deletes happen in parallel; failures surface
+// individually and final cleanup runs once all resolve.
+function bulkDeleteSelected() {
+    const toDelete = S.selectedNodes.slice();
+    if (toDelete.length === 0) {
+        WMNGToast.info('Nothing selected to delete', { duration: 2000 });
+        return;
+    }
+
+    showEditorConfirm(
+        'Delete Selected',
+        `Delete ${toDelete.length} node(s) and their attached links? This can be undone with the editor undo history.`,
+        'Delete Selected',
+        'btn-danger',
+        function () {
+            saveState(); // Save for undo
+
+            const confirmCleanup = function () {
+                const ids = new Set(toDelete.map(n => n.id).concat(toDelete.map(n => n.dbId).filter(Boolean)));
+                S.selectedNodes = [];
+                S.selectedNode = null;
+                S.nodes = S.nodes.filter(n => toDelete.indexOf(n) < 0);
+                S.links = S.links.filter(l => !ids.has(l.srcId) && !ids.has(l.dstId));
+                populateNodeProperties(null);
+                renderEditor();
+                renderLinksList();
+                updateToolbarState();
+            };
+
+            const pending = toDelete.filter(n => S.mapId && n.dbId);
+            if (pending.length === 0) {
+                confirmCleanup();
+                return;
+            }
+
+            let remaining = pending.length;
+            let failed = false;
+            pending.forEach(n => {
+                fetch(S.uris.map + '/' + S.mapId + '/node/' + n.dbId, {
+                    method: 'DELETE',
+                    headers: { 'X-CSRF-TOKEN': getCsrfToken() }
+                })
+                    .then(r => {
+                        if (!r.ok) {
+                            throw new Error('HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : ''));
+                        }
+                        return r.json().catch(() => ({}));
+                    })
+                    .then(data => {
+                        if (data.success === false) {
+                            throw new Error(data.message || 'Server refused to delete node');
+                        }
+                    })
+                    .catch(err => {
+                        failed = true;
+                        WMNGToast.error('Failed to delete node: ' + err.message, { duration: 3000 });
+                    })
+                    .finally(() => {
+                        remaining -= 1;
+                        if (remaining === 0) {
+                            confirmCleanup();
+                            if (failed) {
+                                WMNGToast.warning('Some nodes could not be deleted. Reload the map to refresh.', { duration: 5000 });
+                            }
+                        }
+                    });
+            });
+        }
+    );
 }
 
 // --- Page bootstrap: init the canvas, load the map and device list ---

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -212,11 +212,18 @@
         <button type="button" class="tool-btn" id="snap-grid-btn" onclick="toggleSnapToGrid()" title="Snap to Grid" aria-label="Toggle snap to grid">
             <i class="fas fa-th"></i>
         </button>
+        <div class="tool-divider"></div>
+        <button type="button" class="tool-btn" id="select-mode-btn" onclick="toggleSelectionMode()" title="Multi-select" aria-label="Toggle multi-select (rubber-band) mode">
+            <i class="fas fa-vector-square"></i>
+        </button>
         <button type="button" class="tool-btn" onclick="duplicateSelectedNode()" title="Duplicate Selected" id="duplicate-btn" aria-label="Duplicate selected node" disabled>
             <i class="fas fa-copy"></i>
         </button>
         <button type="button" class="tool-btn" onclick="deleteSelectedNode()" title="Delete Selected" id="delete-node-btn" aria-label="Delete selected node" disabled>
             <i class="fas fa-trash"></i>
+        </button>
+        <button type="button" class="tool-btn" onclick="bulkDeleteSelected()" title="Delete Selected Nodes" id="bulk-delete-btn" aria-label="Bulk delete selected nodes" disabled>
+            <i class="fas fa-trash-can"></i>
         </button>
         <div class="tool-divider"></div>
         <button type="button" class="tool-btn" onclick="undo()" title="Undo (Ctrl+Z)" aria-label="Undo">


### PR DESCRIPTION
## Summary\nAdds multi-select and bulk delete to the editor, building on the modularized editor JS (PR #38). Frontend-only — no backend changes (per-node DELETE endpoints cascade attached links via NodeService).\n\n## Changes (resources/js + editor.blade.php)\n- **Multi-select state** (`S.selectedNodes`) alongside the existing `S.selectedNode` drag anchor — `EditorState`.\n- **Rubber-band marquee**: `select-mode-btn` toolbar toggle (crosshair cursor, dashed rect overlay). Empty-click drag in selection mode selects all nodes intersecting the rect; release position is captured so a drag ending without a final mousemove still selects correctly.\n- **Shift/ctrl-click additive** selection + toggle on canvas (and `selectNodeByIndex`)\uff1b single click keeps normal behavior.\n- **Bulk delete**: `bulk-delete-btn` (gated on selection \u22651). Confirm modal → undo snapshot (`saveState()`) → parallel per-node DELETE for saved nodes (DB cascades links) + local splice otherwise → re-render. Failures surface per-node and warn if any failed.\n- **Render + state consistency**: `drawNode` and the nodes sidebar highlight the whole selection set; `undo`/`redo`/Escape reset `S.selectedNodes`.\n\n## Verification\nDriven in a real containerized LibreNMS browser (CDP, fresh loads):\n- marquee drag over a 3-node cluster selected exactly the 2 nodes inside the rect;\n- bulk-delete button enabled on selection \u22651, confirm removed those nodes (1 left outside the rect);\n- shift-click behind plain single-select and additive/toggle (`N1` \u2192 `N1,N2` \u2192 `N2`);\n- zero `pageerror` across all flows.\n\nPHPUnit: **342 tests / 1064 assertions / 1 skip, green** (JS goes through `editor_source()` in content tests; +4 assertions from the new functions). No new PHP code.