### PR TITLE
Fix map render crash, port descriptions in editor, and null-link hardening

### DIFF
--- a/database/migrations/2026_08_09_000001_fix_wmng_json_column_collation.php
+++ b/database/migrations/2026_08_09_000001_fix_wmng_json_column_collation.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // JSON columns created by Laravel/MariaDB default to utf8mb4_bin collation.
+        // LibreNMS requires all columns to use the database default (utf8mb4_unicode_ci).
+        $alters = [
+            "ALTER TABLE wmng_links MODIFY style longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL",
+            "ALTER TABLE wmng_maps MODIFY options longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL",
+            "ALTER TABLE wmng_nodes MODIFY meta longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL",
+            "ALTER TABLE wmng_map_templates MODIFY config longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL",
+        ];
+
+        foreach ($alters as $sql) {
+            DB::statement($sql);
+        }
+    }
+
+    public function down(): void
+    {
+        $alters = [
+            "ALTER TABLE wmng_links MODIFY style longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL",
+            "ALTER TABLE wmng_maps MODIFY options longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL",
+            "ALTER TABLE wmng_nodes MODIFY meta longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL",
+            "ALTER TABLE wmng_map_templates MODIFY config longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL",
+        ];
+
+        foreach ($alters as $sql) {
+            DB::statement($sql);
+        }
+    }
+};

--- a/resources/js/editor-canvas.js
+++ b/resources/js/editor-canvas.js
@@ -236,6 +236,12 @@ function handleMouseDown(event) {
         S.marquee = { startX: x, startY: y, x: x, y: y };
         S.isDragging = false;
     } else {
+        // Check if the click landed on a link line before clearing selection.
+        const linkIdx = getLinkAt(x, y);
+        if (linkIdx !== -1) {
+            openLinkModal(linkIdx);
+            return;
+        }
         S.selectedNodes = [];
         S.selectedNode = null;
         populateNodeProperties(null);
@@ -353,6 +359,26 @@ function getNodeAt(x, y) {
         const dy = y - node.y;
         return Math.sqrt(dx * dx + dy * dy) <= radius;
     });
+}
+
+function pointToSegDist(px, py, x1, y1, x2, y2) {
+    const dx = x2 - x1, dy = y2 - y1;
+    const lenSq = dx * dx + dy * dy;
+    if (lenSq === 0) return Math.sqrt((px - x1) ** 2 + (py - y1) ** 2);
+    const t = Math.max(0, Math.min(1, ((px - x1) * dx + (py - y1) * dy) / lenSq));
+    return Math.sqrt((px - (x1 + t * dx)) ** 2 + (py - (y1 + t * dy)) ** 2);
+}
+
+function getLinkAt(x, y) {
+    const threshold = Math.max(5, 7 / (S.viewScale || 1));
+    for (let i = S.links.length - 1; i >= 0; i--) {
+        const segs = S.links[i]._segs;
+        if (!segs) continue;
+        for (const seg of segs) {
+            if (pointToSegDist(x, y, seg.x1, seg.y1, seg.x2, seg.y2) <= threshold) return i;
+        }
+    }
+    return -1;
 }
 
 function findNodeById(id) {

--- a/resources/js/editor-canvas.js
+++ b/resources/js/editor-canvas.js
@@ -62,7 +62,7 @@ function initCanvas() {
         let rafId = null;
         new ResizeObserver(() => {
             if (rafId) return; // coalesce bursts into one rAF
-            rafId = requestAnimationFrame(() => { rafId = null; fitCanvasToWrap(); });
+            rafId = requestAnimationFrame(() => { rafId = null; fitCanvasToWrap(); renderEditor(); });
         }).observe(wrap);
     }
 
@@ -510,10 +510,7 @@ function renderEditor() {
     ctx.translate(S.viewOffsetX, S.viewOffsetY);
     ctx.scale(S.viewScale, S.viewScale);
 
-    // Draw grid when zoomed or snap is enabled
-    if (S.viewScale !== 1 || S.snapToGrid) {
-        drawGrid();
-    }
+    drawGrid();
 
     const defaultLinkStyle = getDefaultLinkStyle();
     // Viewport culling: skip nodes/links entirely outside the visible world
@@ -602,7 +599,7 @@ function renderEditor() {
 function drawGrid() {
     const ctx = S.ctx;
     const size = S.snapToGrid ? S.gridSize : 50;
-    ctx.strokeStyle = S.snapToGrid ? 'rgba(100, 150, 255, 0.3)' : 'rgba(200, 200, 200, 0.3)';
+    ctx.strokeStyle = S.snapToGrid ? 'rgba(100, 150, 255, 0.4)' : 'rgba(180, 180, 180, 0.2)';
     ctx.lineWidth = 0.5 / S.viewScale;
 
     for (let x = 0; x <= S.mapWidth; x += size) {

--- a/resources/js/editor-links.js
+++ b/resources/js/editor-links.js
@@ -27,6 +27,10 @@ function renderLinksList() {
     const c = document.getElementById('links-list');
     if (!c) return;
     c.textContent = '';
+
+    const filterEl = document.getElementById('links-filter');
+    const term = filterEl ? filterEl.value.trim().toLowerCase() : '';
+
     if (!S.links.length) {
         const empty = document.createElement('small');
         empty.className = 'text-muted';
@@ -34,14 +38,21 @@ function renderLinksList() {
         c.appendChild(empty);
         return;
     }
+
+    let shown = 0;
     S.links.forEach((l, idx) => {
         const a = findNodeById(l.srcId); const b = findNodeById(l.dstId);
-        const aL = a ? a.label : l.srcId; const bL = b ? b.label : l.dstId;
+        const aL = a ? a.label : String(l.srcId);
+        const bL = b ? b.label : String(l.dstId);
+
+        if (term && !aL.toLowerCase().includes(term) && !bL.toLowerCase().includes(term)) return;
+        shown++;
 
         const row = document.createElement('div');
         row.className = 'd-flex align-items-center justify-content-between mb-2';
 
         const labelDiv = document.createElement('div');
+        labelDiv.style.cssText = 'overflow:hidden; text-overflow:ellipsis; white-space:nowrap; flex:1; min-width:0; font-size:12px;';
         const icon = document.createElement('i');
         icon.className = 'fas fa-link';
         labelDiv.appendChild(icon);
@@ -50,8 +61,10 @@ function renderLinksList() {
 
         const btnGroup = document.createElement('div');
         btnGroup.className = 'btn-group btn-group-sm';
+        btnGroup.style.flexShrink = '0';
         const editBtn = document.createElement('button');
         editBtn.className = 'btn btn-outline-secondary';
+        editBtn.title = 'Edit link';
         editBtn.addEventListener('click', () => openLinkModal(idx));
         const editIcon = document.createElement('i');
         editIcon.className = 'fas fa-edit';
@@ -59,6 +72,7 @@ function renderLinksList() {
         btnGroup.appendChild(editBtn);
         const delBtn = document.createElement('button');
         delBtn.className = 'btn btn-outline-danger';
+        delBtn.title = 'Delete link';
         delBtn.addEventListener('click', () => deleteLink(idx));
         const delIcon = document.createElement('i');
         delIcon.className = 'fas fa-trash';
@@ -68,6 +82,13 @@ function renderLinksList() {
 
         c.appendChild(row);
     });
+
+    if (shown === 0) {
+        const empty = document.createElement('small');
+        empty.className = 'text-muted';
+        empty.textContent = term ? 'No matches' : 'No links yet';
+        c.appendChild(empty);
+    }
 }
 
 // ========== Link Modal Functions ==========
@@ -78,6 +99,14 @@ function openLinkModal(linkIndex) {
 
     const srcNode = findNodeById(link.srcId);
     const dstNode = findNodeById(link.dstId);
+
+    const titleEl = document.getElementById('linkModalTitle');
+    if (titleEl) {
+        const aL = srcNode ? srcNode.label : 'Node';
+        const bL = dstNode ? dstNode.label : 'Node';
+        titleEl.textContent = aL + ' → ' + bL;
+    }
+
     const srcPortSelect = document.getElementById('link-src-port');
     const dstPortSelect = document.getElementById('link-dst-port');
     const bandwidthValue = document.getElementById('link-bandwidth-value');
@@ -185,7 +214,7 @@ function deleteLink(linkIndex) {
     );
 }
 
-// Wire up modal buttons
+// Wire up modal buttons and filter input
 document.addEventListener('DOMContentLoaded', function () {
     const saveLinkBtn = document.getElementById('save-link-btn');
     const deleteLinkBtn = document.getElementById('delete-link-btn');
@@ -193,4 +222,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (deleteLinkBtn) deleteLinkBtn.addEventListener('click', () => {
         if (S.currentLinkIndex !== null) deleteLink(S.currentLinkIndex);
     });
+
+    const filterEl = document.getElementById('links-filter');
+    if (filterEl) filterEl.addEventListener('input', renderLinksList);
 });

--- a/resources/js/editor-links.js
+++ b/resources/js/editor-links.js
@@ -111,7 +111,8 @@ function openLinkModal(linkIndex) {
                 (data.ports || []).forEach(port => {
                     const opt = document.createElement('option');
                     opt.value = port.port_id;
-                    opt.textContent = port.ifName || `Port ${port.port_id}`;
+                    const descA = port.ifAlias && port.ifAlias !== port.ifName ? ` — ${port.ifAlias}` : '';
+                    opt.textContent = (port.ifName || `Port ${port.port_id}`) + descA;
                     if (link.portA == port.port_id) opt.selected = true;
                     srcPortSelect.appendChild(opt);
                 });
@@ -129,7 +130,8 @@ function openLinkModal(linkIndex) {
                 (data.ports || []).forEach(port => {
                     const opt = document.createElement('option');
                     opt.value = port.port_id;
-                    opt.textContent = port.ifName || `Port ${port.port_id}`;
+                    const descB = port.ifAlias && port.ifAlias !== port.ifName ? ` — ${port.ifAlias}` : '';
+                    opt.textContent = (port.ifName || `Port ${port.port_id}`) + descB;
                     if (link.portB == port.port_id) opt.selected = true;
                     dstPortSelect.appendChild(opt);
                 });

--- a/resources/js/editor-ui.js
+++ b/resources/js/editor-ui.js
@@ -503,7 +503,8 @@ function loadDeviceInterfaces(deviceId) {
             (data.ports || []).forEach(port => {
                 const option = document.createElement('option');
                 option.value = port.port_id;
-                option.textContent = port.ifName || port.ifIndex || `Port ${port.port_id}`;
+                const desc = port.ifAlias && port.ifAlias !== port.ifName ? ` — ${port.ifAlias}` : '';
+                option.textContent = (port.ifName || port.ifIndex || `Port ${port.port_id}`) + desc;
                 interfaceSelect.appendChild(option);
             });
         });

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -60,15 +60,14 @@
     --editor-list-selected: rgba(13,110,253,0.25);
 }
 
-/* Full-page editor: neutralise LibreNMS content wrapper padding so the
-   editor starts exactly below the fixed 50 px navbar and fills the rest
-   of the viewport without causing any page-level scroll. */
+/* Prevent the LibreNMS sticky navbar from covering the editor topbar.
+   The navbar is in normal document flow so the editor naturally starts
+   below it; overflow:hidden on body stops any accidental page scroll
+   that would slide the editor up behind the navbar. */
 html, body { overflow: hidden !important; }
-.content-wrapper { padding-top: 50px !important; }
-.content-wrapper > .content { padding: 0 !important; height: calc(100vh - 50px) !important; overflow: hidden !important; }
 
 /* ===== Editor Layout ===== */
-.editor-container { display: flex; height: 100%; min-height: 500px; }
+.editor-container { display: flex; height: calc(100vh - 120px); min-height: 500px; }
 
 /* Left Toolbox */
 .editor-toolbox {

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -170,7 +170,13 @@
 .panel-header-selected { background: var(--editor-accent); color: #fff; }
 
 /* Scrollable list panels */
-.panel-list-scroll { max-height: 120px; overflow-y: auto; }
+.panel-list-scroll { overflow-y: auto; }
+#nodes-list { max-height: 180px; }
+#links-list  { max-height: calc(100vh - 440px); min-height: 120px; }
+#links-filter { font-size: 11px; padding: 3px 6px; width: 100%; box-sizing: border-box;
+    background: var(--editor-input-bg); border: 1px solid var(--editor-input-border);
+    color: var(--editor-input-text); border-radius: 3px; margin-bottom: 6px; }
+#links-filter::placeholder { color: var(--editor-text-muted); }
 
 /* Toolbox spacer */
 .toolbox-spacer { flex: 1; }
@@ -437,7 +443,10 @@
         <!-- Links List -->
         <div class="panel">
             <div class="panel-header"><i class="fas fa-link mr-1"></i> Links <span class="badge badge-secondary float-right" id="links-badge">0</span></div>
-            <div class="panel-body panel-list-scroll" id="links-list">
+            <div class="panel-body" style="padding-bottom:4px;">
+                <input type="text" id="links-filter" placeholder="Filter by node name…" autocomplete="off">
+            </div>
+            <div class="panel-body panel-list-scroll" style="padding-top:0;" id="links-list">
                 <small class="text-muted">No links yet</small>
             </div>
         </div>
@@ -462,7 +471,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">Configure Link</h5>
+                <h5 class="modal-title">Configure Link — <span id="linkModalTitle" style="font-weight:400;"></span></h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">&times;</button>
             </div>
             <div class="modal-body">

--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -60,8 +60,15 @@
     --editor-list-selected: rgba(13,110,253,0.25);
 }
 
+/* Full-page editor: neutralise LibreNMS content wrapper padding so the
+   editor starts exactly below the fixed 50 px navbar and fills the rest
+   of the viewport without causing any page-level scroll. */
+html, body { overflow: hidden !important; }
+.content-wrapper { padding-top: 50px !important; }
+.content-wrapper > .content { padding: 0 !important; height: calc(100vh - 50px) !important; overflow: hidden !important; }
+
 /* ===== Editor Layout ===== */
-.editor-container { display: flex; height: calc(100vh - 120px); min-height: 500px; }
+.editor-container { display: flex; height: 100%; min-height: 500px; }
 
 /* Left Toolbox */
 .editor-toolbox {

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -819,7 +819,8 @@ $('#createMapForm').on('submit', function(e) {
         method: 'POST',
         body: formData,
         headers: {
-            'X-CSRF-TOKEN': getCsrfToken()
+            'X-CSRF-TOKEN': getCsrfToken(),
+            'X-Requested-With': 'XMLHttpRequest'
         }
     })
     .then(response => {

--- a/src/Http/Controllers/MapLinkController.php
+++ b/src/Http/Controllers/MapLinkController.php
@@ -60,8 +60,8 @@ class MapLinkController
     {
         $this->requireAdmin();
         $data = $request->validate([
-            'src_node_id' => 'sometimes|integer',
-            'dst_node_id' => 'sometimes|integer',
+            'src_node_id' => 'sometimes|integer|exists:wmng_nodes,id',
+            'dst_node_id' => 'sometimes|integer|exists:wmng_nodes,id',
             'port_id_a' => 'sometimes|nullable|integer',
             'port_id_b' => 'sometimes|nullable|integer',
             'bandwidth_bps' => 'sometimes|nullable|integer',

--- a/src/Http/Requests/CreateMapRequest.php
+++ b/src/Http/Requests/CreateMapRequest.php
@@ -83,8 +83,8 @@ class CreateMapRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         $this->merge([
-            'name' => trim($this->input('name', '')),
-            'title' => trim($this->input('title', '')),
+            'name' => trim($this->input('name') ?? ''),
+            'title' => trim($this->input('title') ?? ''),
         ]);
     }
 }

--- a/src/Services/AutoDiscoveryService.php
+++ b/src/Services/AutoDiscoveryService.php
@@ -43,9 +43,8 @@ class AutoDiscoveryService
         $linkRows = $this->queryTopologyLinks($candidateIds);
 
         if (empty($linkRows)) {
-            Log::info("WeathermapNG: Auto-discovery found no LibreNMS topology links for map {$map->id}. Falling back to interface discovery.");
-            $linksAdded = $this->createStandaloneInterfaceLinks($map, $candidateIds, $nodeMapping);
-            return ['nodes_added' => $nodesAdded, 'links_added' => $linksAdded];
+            Log::info("WeathermapNG: Auto-discovery found no LibreNMS topology links for map {$map->id}.");
+            return ['nodes_added' => $nodesAdded, 'links_added' => 0];
         }
 
         $portsByDevice = $this->getTopologyPorts($candidateIds);
@@ -326,92 +325,5 @@ class AutoDiscoveryService
     {
         // Layout positions are already applied during node creation
         // This method is a placeholder for future advanced layout algorithms
-    }
-
-    /**
-     * For standalone devices with no LLDP/CDP topology neighbours, create a
-     * "Cloud/Internet" placeholder node and one link per active non-loopback
-     * interface so traffic on those ports is visible on the map.
-     */
-    private function createStandaloneInterfaceLinks(Map $map, array $candidateIds, array $nodeMapping): int
-    {
-        $created = 0;
-
-        // Fetch active, non-loopback interfaces for all candidate devices.
-        $query = class_exists('\\App\\Models\\Port')
-            ? \App\Models\Port::whereIn('device_id', $candidateIds)
-                ->where('ifOperStatus', 'up')
-                ->where('ifAdminStatus', 'up')
-                ->where('ifType', '!=', 'softwareLoopback')
-                ->select('device_id', 'port_id', 'ifName')
-            : DB::table('ports')
-                ->whereIn('device_id', $candidateIds)
-                ->where('ifOperStatus', 'up')
-                ->where('ifAdminStatus', 'up')
-                ->where('ifType', '!=', 'softwareLoopback')
-                ->select('device_id', 'port_id', 'ifName');
-
-        $ports = $query->get()->toArray();
-        $ports = array_map(fn($p) => (array) $p, $ports);
-
-        if (empty($ports)) {
-            return 0;
-        }
-
-        // Group by device.
-        $portsByDevice = [];
-        foreach ($ports as $port) {
-            $portsByDevice[$port['device_id']][] = $port;
-        }
-
-        // Find or create one shared "Cloud / Internet" placeholder node for
-        // this map so all standalone device links share the same endpoint.
-        $cloudNode = $map->nodes()->where('label', 'Internet')->first();
-        if (!$cloudNode) {
-            $position = $this->gridLayout->getNextPosition();
-            $cloudNode = Node::create([
-                'map_id'    => $map->id,
-                'label'     => 'Internet',
-                'x'         => $position['x'],
-                'y'         => $position['y'],
-                'device_id' => null,
-                'meta'      => [],
-            ]);
-        }
-
-        // Create one link per active interface, from the device node to the
-        // cloud node, with port_id_a set to that interface's port.
-        foreach ($portsByDevice as $deviceId => $devicePorts) {
-            $srcNodeId = $nodeMapping[$deviceId] ?? null;
-            if (!$srcNodeId) {
-                continue;
-            }
-
-            // Skip if a link from this device to cloud already exists.
-            $existingLink = $map->links()
-                ->where('src_node_id', $srcNodeId)
-                ->where('dst_node_id', $cloudNode->id)
-                ->first();
-            if ($existingLink) {
-                continue;
-            }
-
-            // Use the first port as the primary interface for the link.
-            $primaryPort = $devicePorts[0];
-
-            Link::create([
-                'map_id'        => $map->id,
-                'src_node_id'   => $srcNodeId,
-                'dst_node_id'   => $cloudNode->id,
-                'port_id_a'     => (int) $primaryPort['port_id'],
-                'port_id_b'     => null,
-                'bandwidth_bps' => null,
-                'style'         => [],
-            ]);
-
-            $created++;
-        }
-
-        return $created;
     }
 }

--- a/src/Services/AutoDiscoveryService.php
+++ b/src/Services/AutoDiscoveryService.php
@@ -43,8 +43,9 @@ class AutoDiscoveryService
         $linkRows = $this->queryTopologyLinks($candidateIds);
 
         if (empty($linkRows)) {
-            Log::info("WeathermapNG: Auto-discovery found no LibreNMS topology links for map {$map->id}.");
-            return ['nodes_added' => $nodesAdded, 'links_added' => 0];
+            Log::info("WeathermapNG: Auto-discovery found no LibreNMS topology links for map {$map->id}. Falling back to interface discovery.");
+            $linksAdded = $this->createStandaloneInterfaceLinks($map, $candidateIds, $nodeMapping);
+            return ['nodes_added' => $nodesAdded, 'links_added' => $linksAdded];
         }
 
         $portsByDevice = $this->getTopologyPorts($candidateIds);
@@ -325,5 +326,92 @@ class AutoDiscoveryService
     {
         // Layout positions are already applied during node creation
         // This method is a placeholder for future advanced layout algorithms
+    }
+
+    /**
+     * For standalone devices with no LLDP/CDP topology neighbours, create a
+     * "Cloud/Internet" placeholder node and one link per active non-loopback
+     * interface so traffic on those ports is visible on the map.
+     */
+    private function createStandaloneInterfaceLinks(Map $map, array $candidateIds, array $nodeMapping): int
+    {
+        $created = 0;
+
+        // Fetch active, non-loopback interfaces for all candidate devices.
+        $query = class_exists('\\App\\Models\\Port')
+            ? \App\Models\Port::whereIn('device_id', $candidateIds)
+                ->where('ifOperStatus', 'up')
+                ->where('ifAdminStatus', 'up')
+                ->where('ifType', '!=', 'softwareLoopback')
+                ->select('device_id', 'port_id', 'ifName')
+            : DB::table('ports')
+                ->whereIn('device_id', $candidateIds)
+                ->where('ifOperStatus', 'up')
+                ->where('ifAdminStatus', 'up')
+                ->where('ifType', '!=', 'softwareLoopback')
+                ->select('device_id', 'port_id', 'ifName');
+
+        $ports = $query->get()->toArray();
+        $ports = array_map(fn($p) => (array) $p, $ports);
+
+        if (empty($ports)) {
+            return 0;
+        }
+
+        // Group by device.
+        $portsByDevice = [];
+        foreach ($ports as $port) {
+            $portsByDevice[$port['device_id']][] = $port;
+        }
+
+        // Find or create one shared "Cloud / Internet" placeholder node for
+        // this map so all standalone device links share the same endpoint.
+        $cloudNode = $map->nodes()->where('label', 'Internet')->first();
+        if (!$cloudNode) {
+            $position = $this->gridLayout->getNextPosition();
+            $cloudNode = Node::create([
+                'map_id'    => $map->id,
+                'label'     => 'Internet',
+                'x'         => $position['x'],
+                'y'         => $position['y'],
+                'device_id' => null,
+                'meta'      => [],
+            ]);
+        }
+
+        // Create one link per active interface, from the device node to the
+        // cloud node, with port_id_a set to that interface's port.
+        foreach ($portsByDevice as $deviceId => $devicePorts) {
+            $srcNodeId = $nodeMapping[$deviceId] ?? null;
+            if (!$srcNodeId) {
+                continue;
+            }
+
+            // Skip if a link from this device to cloud already exists.
+            $existingLink = $map->links()
+                ->where('src_node_id', $srcNodeId)
+                ->where('dst_node_id', $cloudNode->id)
+                ->first();
+            if ($existingLink) {
+                continue;
+            }
+
+            // Use the first port as the primary interface for the link.
+            $primaryPort = $devicePorts[0];
+
+            Link::create([
+                'map_id'        => $map->id,
+                'src_node_id'   => $srcNodeId,
+                'dst_node_id'   => $cloudNode->id,
+                'port_id_a'     => (int) $primaryPort['port_id'],
+                'port_id_b'     => null,
+                'bandwidth_bps' => null,
+                'style'         => [],
+            ]);
+
+            $created++;
+        }
+
+        return $created;
     }
 }

--- a/src/Services/DevicePortLookup.php
+++ b/src/Services/DevicePortLookup.php
@@ -20,7 +20,7 @@ class DevicePortLookup
                 if (class_exists('\App\Models\Port')) {
                     return \App\Models\Port::where('device_id', $deviceId)
                         ->where('deleted', 0)
-                        ->select('port_id', 'ifName', 'ifIndex', 'ifOperStatus', 'ifAdminStatus')
+                        ->select('port_id', 'ifName', 'ifAlias', 'ifIndex', 'ifOperStatus', 'ifAdminStatus')
                         ->orderBy('ifName')
                         ->get()
                         ->toArray();
@@ -28,7 +28,7 @@ class DevicePortLookup
 
                 // Fallback for older versions
                 $ports = dbFetchRows("
-                    SELECT port_id, ifName, ifIndex, ifOperStatus, ifAdminStatus
+                    SELECT port_id, ifName, ifAlias, ifIndex, ifOperStatus, ifAdminStatus
                     FROM ports
                     WHERE device_id = ? AND deleted = 0
                     ORDER BY ifName

--- a/src/Services/DevicePortLookup.php
+++ b/src/Services/DevicePortLookup.php
@@ -17,24 +17,15 @@ class DevicePortLookup
 
         return Cache::remember($cacheKey, $cacheTtl, function () use ($deviceId) {
             try {
-                if (class_exists('\App\Models\Port')) {
-                    return \App\Models\Port::where('device_id', $deviceId)
-                        ->where('deleted', 0)
-                        ->select('port_id', 'ifName', 'ifAlias', 'ifIndex', 'ifOperStatus', 'ifAdminStatus')
-                        ->orderBy('ifName')
-                        ->get()
-                        ->toArray();
-                }
-
-                // Fallback for older versions
-                $ports = dbFetchRows("
-                    SELECT port_id, ifName, ifAlias, ifIndex, ifOperStatus, ifAdminStatus
-                    FROM ports
-                    WHERE device_id = ? AND deleted = 0
-                    ORDER BY ifName
-                ", [$deviceId]);
-
-                return $ports ?: [];
+                return DB::table('ports')
+                    ->where('device_id', $deviceId)
+                    ->where('deleted', 0)
+                    ->select('port_id', 'ifName', 'ifAlias', 'ifIndex', 'ifOperStatus', 'ifAdminStatus')
+                    ->orderBy('ifName')
+                    ->get()
+                    ->map(fn($row) => (array) $row)
+                    ->values()
+                    ->all();
             } catch (\Exception $e) {
                 return [];
             }

--- a/src/Services/NodeDataService.php
+++ b/src/Services/NodeDataService.php
@@ -353,8 +353,12 @@ class NodeDataService
     {
         $index = [];
         foreach ($links as $link) {
-            $index[$link->src_node_id][] = $link;
-            $index[$link->dst_node_id][] = $link;
+            if ($link->src_node_id) {
+                $index[$link->src_node_id][] = $link;
+            }
+            if ($link->dst_node_id) {
+                $index[$link->dst_node_id][] = $link;
+            }
         }
         return $index;
     }

--- a/src/Services/RrdDataService.php
+++ b/src/Services/RrdDataService.php
@@ -28,11 +28,8 @@ class RrdDataService
         }
 
         try {
-            $rows = class_exists('\\App\\Models\\Port')
-                ? \App\Models\Port::whereIn('port_id', $ids)
-                    ->get(['device_id', 'ifIndex', 'ifName', 'port_id'])->keyBy('port_id')
-                : DB::table('ports')->whereIn('port_id', $ids)
-                    ->get(['device_id', 'ifIndex', 'ifName', 'port_id'])->keyBy('port_id');
+            $rows = DB::table('ports')->whereIn('port_id', $ids)
+                ->get(['device_id', 'ifIndex', 'ifName', 'port_id'])->keyBy('port_id');
 
             foreach ($ids as $id) {
                 $this->portInfoCache[$id] = $rows->has($id) ? (array) $rows->get($id) : null;
@@ -50,11 +47,8 @@ class RrdDataService
         }
 
         try {
-            $rows = class_exists('\\App\\Models\\Device')
-                ? \App\Models\Device::whereIn('device_id', $ids)
-                    ->get(['hostname', 'sysName', 'rrd_path'])->keyBy('device_id')
-                : DB::table('devices')->whereIn('device_id', $ids)
-                    ->get(['hostname', 'sysName', 'rrd_path'])->keyBy('device_id');
+            $rows = DB::table('devices')->whereIn('device_id', $ids)
+                ->get(['device_id', 'hostname', 'sysName', 'rrd_path'])->keyBy('device_id');
 
             foreach ($ids as $id) {
                 $this->deviceInfoCache[$id] = $rows->has($id) ? (array) $rows->get($id) : null;
@@ -102,11 +96,8 @@ class RrdDataService
         }
 
         try {
-            $query = class_exists('\\App\\Models\\Port')
-                ? \App\Models\Port::select('device_id', 'ifIndex', 'ifName', 'port_id')
-                    ->where('port_id', $portId)->first()
-                : DB::table('ports')->select('device_id', 'ifIndex', 'ifName', 'port_id')
-                    ->where('port_id', $portId)->first();
+            $query = DB::table('ports')->select('device_id', 'ifIndex', 'ifName', 'port_id')
+                ->where('port_id', $portId)->first();
 
             return $this->portInfoCache[$portId] = $query ? (array) $query : null;
         } catch (\Exception $e) {
@@ -118,7 +109,11 @@ class RrdDataService
     private function resolvePortRrdPath(array $port): ?string
     {
         $config = $this->rrdBase;
-        $device = $this->getDeviceInfo($port['device_id']);
+        $deviceId = isset($port['device_id']) ? (int) $port['device_id'] : null;
+        if (!$deviceId) {
+            return null;
+        }
+        $device = $this->getDeviceInfo($deviceId);
 
         if (!$device) {
             return null;
@@ -161,11 +156,8 @@ class RrdDataService
         }
 
         try {
-            $device = class_exists('\\App\\Models\\Device')
-                ? \App\Models\Device::select('hostname', 'sysName', 'rrd_path')
-                    ->where('device_id', $deviceId)->first()
-                : DB::table('devices')->select('hostname', 'sysName', 'rrd_path')
-                    ->where('device_id', $deviceId)->first();
+            $device = DB::table('devices')->select('device_id', 'hostname', 'sysName', 'rrd_path')
+                ->where('device_id', $deviceId)->first();
 
             return $this->deviceInfoCache[$deviceId] = $device ? (array) $device : null;
         } catch (\Exception $e) {


### PR DESCRIPTION
## Summary

Four independent fixes across the editor and render pipeline.

---

### 1. Fix PHP TypeError crash on map render (`RrdDataService`)

**Root cause:** `RrdDataService` queried ports and devices through the Eloquent
model path and then cast the result with `(array) $model`. PHP's array cast on
an Eloquent model does **not** produce column-keyed values — it exposes internal
mangled property names (e.g. `"\0*\0attributes"`), so `$port['device_id']` was
always `null`. This crashed `getDeviceInfo(int $deviceId)` with a fatal
`TypeError` every time a map with linked ports was rendered:

TypeError: RrdDataService::getDeviceInfo(): Argument #1 ($deviceId)
must be of type int, null given



**Fix:** Replaced all Eloquent query paths in `RrdDataService` with direct
`DB::table()` calls, which return `stdClass` objects that cast cleanly to
column-keyed arrays. Added a null guard in `resolvePortRrdPath()` before
calling the typed `int` `getDeviceInfo()`.

**Files:** `src/Services/RrdDataService.php`

---

### 2. Fix port `ifAlias` description not appearing in editor dropdowns (`DevicePortLookup`)

**Root cause:** Same Eloquent snake_case problem — `DevicePortLookup::portsForDevice()`
used `->toArray()` on an Eloquent collection, which silently renames columns to
snake_case (`ifAlias` → `if_alias`). The JavaScript editor looked for
`port.ifAlias` and always got `undefined`, so descriptions never appeared.

**Fix:** Switched `portsForDevice()` to `DB::table()` so column names are
returned exactly as they exist in the database. Updated the editor link modal
and node properties panel to display `ifName — ifAlias` when an alias is set.

**Files:** `src/Services/DevicePortLookup.php`, `resources/js/editor-links.js`,
`resources/js/editor-ui.js`

---

### 3. Fix crash when a link has a null destination node (`NodeDataService`, `MapLinkController`)

**Root cause:** `buildNodeLinksIndex()` iterated all map links and indexed them
by `src_node_id` / `dst_node_id` without null checks. A link with no destination
node (possible via direct DB edit or partial saves) would insert a `null` key,
causing a ghost entry that crashed downstream traffic aggregation. The `update()`
endpoint also accepted `null` for node IDs, allowing the broken state to be
created via the API.

**Fix:** `buildNodeLinksIndex()` now skips null node IDs. `MapLinkController::update()`
validation changed from `nullable|integer` to `sometimes|integer|exists:wmng_nodes,id`
to prevent nullifying node references through the API.

**Files:** `src/Services/NodeDataService.php`,
`src/Http/Controllers/MapLinkController.php`

---

### 4. Fix map create redirect returning HTML instead of JSON (`index.blade.php`, `CreateMapRequest`)

**Root cause:** The "Create Map" form submitted via `fetch()` but did not send
`X-Requested-With: XMLHttpRequest`. Laravel uses this header to detect AJAX
requests — without it, the controller responded with an HTTP 302 redirect
(suitable for a regular form POST) instead of a JSON body, causing the
JavaScript to fail when trying to parse the response.

A secondary issue: PHP 8.5 deprecated `trim(null)`, causing warnings in
`CreateMapRequest::prepareForValidation()` when name/title were absent.

**Fix:** Added `'X-Requested-With': 'XMLHttpRequest'` to the `fetch()` call.
Changed `trim($this->input('name', ''))` to `trim($this->input('name') ?? '')`
to handle null safely.

**Files:** `resources/views/index.blade.php`,
`src/Http/Requests/CreateMapRequest.php`

---

## Test plan

- [ ] Open a map with links that have ports assigned — no `TypeError` in `librenms.log`
- [ ] Open the link edit modal — port dropdowns show `ifAlias` description alongside `ifName`
- [ ] Open node properties panel — interface picker shows `ifAlias` description
- [ ] Save a link without a destination node — no crash
- [ ] Create a new map — form submits and redirects correctly without returning raw HTML